### PR TITLE
Fixed `CodingKeys`

### DIFF
--- a/SwiftyInsta/API/Services/CommentHandler.swift
+++ b/SwiftyInsta/API/Services/CommentHandler.swift
@@ -156,6 +156,7 @@ class CommentHandler: CommentHandlerProtocol {
                 if res?.statusCode == 200 {
                     if let data = data {
                         let decoder = JSONDecoder()
+                        decoder.keyDecodingStrategy = .convertFromSnakeCase
                         do {
                             let value = try decoder.decode(BaseStatusResponseModel.self, from: data)
                             completion(Return.success(value: value))

--- a/SwiftyInsta/API/Services/MediaHandler.swift
+++ b/SwiftyInsta/API/Services/MediaHandler.swift
@@ -642,6 +642,7 @@ class MediaHandler: MediaHandlerProtocol {
             } else {
                 if let data = data {
                     let decoder = JSONDecoder()
+                    decoder.keyDecodingStrategy = .convertFromSnakeCase
                     do {
                         let value = try decoder.decode(DeleteMediaResponse.self, from: data)
                         completion(Return.success(value: value))

--- a/SwiftyInsta/API/Services/StoryHandler.swift
+++ b/SwiftyInsta/API/Services/StoryHandler.swift
@@ -284,6 +284,7 @@ class StoryHandler: StoryHandlerProtocol {
             } else {
                 if let data = data {
                     let decoder = JSONDecoder()
+                    decoder.keyDecodingStrategy = .convertFromSnakeCase
                     do {
                         let value = try decoder.decode(BaseStatusResponseModel.self, from: data)
                         if let status = value.status, status == "ok" {

--- a/SwiftyInsta/API/Services/UserHandler.swift
+++ b/SwiftyInsta/API/Services/UserHandler.swift
@@ -1198,6 +1198,7 @@ class UserHandler: UserHandlerProtocol {
                         if let data = data {
                             if response?.statusCode == 200 {
                                 let decoder = JSONDecoder()
+                                decoder.keyDecodingStrategy = .convertFromSnakeCase
                                 do {
                                     let value = try decoder.decode(AccountRecovery.self, from: data)
                                     completion(Return.success(value: value))

--- a/SwiftyInsta/Classes/Models/MediaModel.swift
+++ b/SwiftyInsta/Classes/Models/MediaModel.swift
@@ -160,11 +160,11 @@ public struct MediaModel: Codable, MediaModelProtocol {
 }
 
 public struct DeleteMediaResponse: Codable, BaseStatusResponseProtocol {
-    public var did_delete: Bool?
+    public var didDelete: Bool?
     public var status: String?
     
-    public init(did_delete: Bool?, status: String?) {
-        self.did_delete = did_delete
+    public init(didDelete: Bool?, status: String?) {
+        self.didDelete = didDelete
         self.status = status
     }
 }

--- a/SwiftyInsta/Classes/Models/NameTagModel.swift
+++ b/SwiftyInsta/Classes/Models/NameTagModel.swift
@@ -15,10 +15,10 @@ public struct NameTagModel: Codable {
     public var selfieSticker: Int?
     
     private enum CodingKeys: String, CodingKey {
-        case mode = "mode"
-        case gradient = "gradient"
-        case emoji = "emoji"
-        case selfieSticker = "selfie_sticker"
+        case mode
+        case gradient
+        case emoji
+        case selfieSticker
     }
     
     public init(from decoder: Decoder) throws {

--- a/SwiftyInsta/Classes/Models/RecentActivitiesModel.swift
+++ b/SwiftyInsta/Classes/Models/RecentActivitiesModel.swift
@@ -115,10 +115,10 @@ public struct ArgsLinksModel: Codable {
     public var id: String?
     
     private enum CodingKeys: String, CodingKey {
-        case start = "start"
-        case end = "end"
-        case type = "type"
-        case id = "id"
+        case start
+        case end
+        case type
+        case id
     }
     
     public init(from decoder: Decoder) throws {

--- a/SwiftyInsta/Classes/Models/TrayModel.swift
+++ b/SwiftyInsta/Classes/Models/TrayModel.swift
@@ -98,21 +98,21 @@ public struct TrayModel: Codable {
     public var sourceToken: String?
     
     private enum CodingKeys: String, CodingKey {
-        case id = "id"
-        case latestReelMedia = "latest_reel_media"
-        case expiringAt = "expiring_at"
-        case seen = "seen"
-        case canReply = "can_reply"
-        case canReshare = "can_reshare"
-        case reelType = "reel_type"
-        case owner = "owner"
-        case user = "user"
-        case items = "items"
-        case prefetchCount = "prefetch_count"
-        case uniqueIntegerReelId = "unique_integer_reel_id"
-        case rankedPosition = "ranked_position"
-        case seenRankedPosition = "seen_ranked_position"
-        case sourceToken = "source_token"
+        case id
+        case latestReelMedia
+        case expiringAt
+        case seen
+        case canReply
+        case canReshare
+        case reelType
+        case owner
+        case user
+        case items
+        case prefetchCount
+        case uniqueIntegerReelId
+        case rankedPosition
+        case seenRankedPosition
+        case sourceToken
     }
     
     public init(from decoder: Decoder) throws {
@@ -152,10 +152,10 @@ public struct OwnerModel: Codable {
     public var profilePicUsername: String?
     
     private enum CodingKeys: String, CodingKey {
-        case type = "type"
-        case pk = "pk"
-        case profilePicUrl = "profile_pic_url"
-        case profilePicUsername = "profile_pic_username"
+        case type
+        case pk
+        case profilePicUrl
+        case profilePicUsername
     }
     
     public init(from decoder: Decoder) throws {

--- a/SwiftyInsta/Classes/Models/UserFeedModel.swift
+++ b/SwiftyInsta/Classes/Models/UserFeedModel.swift
@@ -17,12 +17,12 @@ public struct UserFeedModel: Codable, FeedProtocol {
     public var items: [MediaModel]?
     
     private enum CodingKeys: String, CodingKey {
-        case nextMaxId = "nextMaxId"
-        case items = "items"
-        case numResults = "numResults"
-        case moreAvailable = "moreAvailable"
-        case autoLoadMoreEnabled = "autoLoadMoreEnabled"
-        case totalCount = "totalCount"
+        case nextMaxId
+        case items
+        case numResults
+        case moreAvailable
+        case autoLoadMoreEnabled
+        case totalCount
     }
     
     public init(from decoder: Decoder) throws {


### PR DESCRIPTION
Fixed `CodingKeys` having a _snake_case_string_ as `rawValue`, interfering with `JSONDecoder`'s `convertFromSnakeCase` `keyDecodingStrategy` and resulting in `nil` properties by mistake.
Everything is matched by default as long as the `case` name in the `CodingKeys` enum with `String` `RawValue` is the _camelCaseString_ version of the corresponding _snake_case_string_ in the _API_.