### PR TITLE
Better pagination

### DIFF
--- a/SwiftyInsta.xcodeproj/project.pbxproj
+++ b/SwiftyInsta.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		11E2B135218F13D20095374A /* UserShortListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E2B134218F13D20095374A /* UserShortListModel.swift */; };
 		11F0CE6B2195CC2400C0F6A4 /* TimeLineModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F0CE6A2195CC2400C0F6A4 /* TimeLineModel.swift */; };
 		11F57CC4229D2E78001A1C0A /* BlockedUsersModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F57CC3229D2E78001A1C0A /* BlockedUsersModel.swift */; };
+		E063077222E253060015AA92 /* PaginationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E063077122E253060015AA92 /* PaginationHandler.swift */; };
 		E8314D5E2210652400D13BEA /* UserTags.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8314D5D2210652400D13BEA /* UserTags.swift */; };
 /* End PBXBuildFile section */
 
@@ -192,6 +193,7 @@
 		11E2B134218F13D20095374A /* UserShortListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserShortListModel.swift; sourceTree = "<group>"; };
 		11F0CE6A2195CC2400C0F6A4 /* TimeLineModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeLineModel.swift; sourceTree = "<group>"; };
 		11F57CC3229D2E78001A1C0A /* BlockedUsersModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUsersModel.swift; sourceTree = "<group>"; };
+		E063077122E253060015AA92 /* PaginationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PaginationHandler.swift; path = ../../../../../../../../../System/Volumes/Data/Users/stefanobertagno/Documents/Development/Libraries/SwiftyInsta/SwiftyInsta/API/Services/PaginationHandler.swift; sourceTree = "<group>"; };
 		E8314D5D2210652400D13BEA /* UserTags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTags.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -272,6 +274,7 @@
 				115F1240217FE98000ED3530 /* APIHandler.swift */,
 				11AE43FC21A99CD400BD9EFB /* CommentHandler.swift */,
 				11AE43FD21A99CD400BD9EFB /* FeedHandler.swift */,
+				E063077122E253060015AA92 /* PaginationHandler.swift */,
 				11AE440221A99CD400BD9EFB /* MediaHandler.swift */,
 				11AE440021A99CD400BD9EFB /* MessageHandler.swift */,
 				11AE43FF21A99CD400BD9EFB /* ProfileHandler.swift */,
@@ -630,6 +633,7 @@
 				1171E47821812C9400579B04 /* LoginResultModel.swift in Sources */,
 				11B9568421945C67006661A6 /* LocationModel.swift in Sources */,
 				115F1253217FEFF200ED3530 /* SessionStorage.swift in Sources */,
+				E063077222E253060015AA92 /* PaginationHandler.swift in Sources */,
 				1104CD092180621400F855BA /* HTTPMethods.swift in Sources */,
 				11E2B135218F13D20095374A /* UserShortListModel.swift in Sources */,
 				11B8518F219F5208009527CD /* UploadMediaModel.swift in Sources */,

--- a/SwiftyInsta/API/Services/APIHandler.swift
+++ b/SwiftyInsta/API/Services/APIHandler.swift
@@ -19,7 +19,6 @@ public protocol APIHandlerProtocol:
 }
 
 public class APIHandler: APIHandlerProtocol {
-    
     public init() {}
     
     public init(request: RequestMessageModel, user: SessionStorage, device: AndroidDeviceModel, delay: DelayModel, urlSession: URLSession) {
@@ -144,68 +143,7 @@ public class APIHandler: APIHandlerProtocol {
             completion(result)
         }
     }
-    
-    public func getUserFollowing(username: String, paginationParameter: PaginationParameters, searchQuery: String = "", completion: @escaping (Result<[UserShortModel]>) -> ()) throws {
-        // validate before request.
-        try validateUser()
-        try validateLoggedIn()
         
-        try UserHandler.shared.getUserFollowing(username: username, paginationParameter: paginationParameter, searchQuery: searchQuery) { (result) in
-            completion(result)
-        }
-    }
-    
-    public func getUserFollowers(username: String, paginationParameter: PaginationParameters, searchQuery: String, completion: @escaping (Result<[UserShortModel]>) -> ()) throws {
-        // validate before request.
-        try validateUser()
-        try validateLoggedIn()
-        
-        try UserHandler.shared.getUserFollowers(username: username, paginationParameter: paginationParameter, searchQuery: searchQuery) { (result) in
-            completion(result)
-        }
-    }
-    
-    /** Searching with Pk returns more accurate results */
-    public func getUserFollowers(pk: Int, paginationParameter: PaginationParameters, searchQuery: String, completion: @escaping (Result<[UserShortModel]>) -> ()) throws {
-        // validate before request.
-        try validateUser()
-        try validateLoggedIn()
-        try UserHandler.shared.getUserFollowers(pk: pk, paginationParameter: paginationParameter, searchQuery: searchQuery) { (result) in
-            completion(result)
-        }
-    }
-    
-    /// receives followers from single page by passing maxId of page.
-    /// for first request, pass `nil` for `maxId` parameter.
-    public func getUserFollowers(userId: Int, maxId: String?, searchQuery: String, completion: @escaping (Result<UserShortListModel>, String?) -> ()) throws {
-        try validateUser()
-        try validateLoggedIn()
-        try UserHandler.shared.getUserFollowers(userId: userId, maxId: maxId, searchQuery: searchQuery, completion: { (result, maxId) in
-            completion(result, maxId)
-        })
-    }
-    
-    /// receives following from single page by passing maxId of page.
-    /// for first request, pass `nil` for `maxId` parameter.
-    public func getUserFollowing(userId: Int, maxId: String?, searchQuery: String, completion: @escaping (Result<UserShortListModel>, String?) -> ()) throws {
-        try validateUser()
-        try validateLoggedIn()
-        try UserHandler.shared.getUserFollowing(userId: userId, maxId: maxId, searchQuery: searchQuery, completion: { (result, maxId) in
-            completion(result, maxId)
-        })
-    }
-    
-    /** Searching with Pk returns more accurate results */
-    public func getUserFollowing(pk: Int, paginationParameter: PaginationParameters, searchQuery: String, completion: @escaping (Result<[UserShortModel]>) -> ()) throws {
-        // validate before request.
-        try validateUser()
-        try validateLoggedIn()
-        
-        try UserHandler.shared.getUserFollowing(pk: pk, paginationParameter: paginationParameter, searchQuery: searchQuery) { (result) in
-            completion(result)
-        }
-    }
-    
     public func getCurrentUser(completion: @escaping (Result<CurrentUserModel>) -> ()) throws {
         // validate before request.
         try validateUser()
@@ -216,56 +154,112 @@ public class APIHandler: APIHandlerProtocol {
         }
     }
     
-    public func getExploreFeeds(paginationParameter: PaginationParameters, completion: @escaping (Result<[ExploreFeedModel]>) -> ()) throws {
+    public func getUserTags(user: UserReference,
+                            paginationParameters: PaginationParameters,
+                            updateHandler: PaginationResponse<UserFeedModel>?,
+                            completionHandler: @escaping PaginationResponse<Result<[UserFeedModel]>>) throws {
+        // validate before request.
+        try validateUser()
+        try validateLoggedIn()
+
+        try UserHandler.shared.getUserTags(user: user,
+                                                paginationParameters: paginationParameters,
+                                                updateHandler: updateHandler,
+                                                completionHandler: completionHandler)
+    }
+    
+    public func getUserFollowing(user: UserReference,
+                                 filteringProfilesMatchingQuery query: String?,
+                                 paginationParameters: PaginationParameters,
+                                 updateHandler: PaginationResponse<UserShortListModel>?,
+                                 completionHandler: @escaping PaginationResponse<Result<[UserShortModel]>>) throws {
+        // validate before request.
+        try validateUser()
+        try validateLoggedIn()
+
+        try UserHandler.shared.getUserFollowing(user: user,
+                                                filteringProfilesMatchingQuery: query,
+                                                paginationParameters: paginationParameters,
+                                                updateHandler: updateHandler,
+                                                completionHandler: completionHandler)
+    }
+    
+    public func getUserFollowers(user: UserReference,
+                                 filteringProfilesMatchingQuery query: String?,
+                                 paginationParameters: PaginationParameters,
+                                 updateHandler: PaginationResponse<UserShortListModel>?,
+                                 completionHandler: @escaping PaginationResponse<Result<[UserShortModel]>>) throws {
+        // validate before request.
+        try validateUser()
+        try validateLoggedIn()
+
+        try UserHandler.shared.getUserFollowers(user: user,
+                                                filteringProfilesMatchingQuery: query,
+                                                paginationParameters: paginationParameters,
+                                                updateHandler: updateHandler,
+                                                completionHandler: completionHandler)
+    }
+    
+    public func getRecentActivities(paginationParameters: PaginationParameters,
+                                    updateHandler: PaginationResponse<RecentActivitiesModel>?,
+                                    completionHandler: @escaping PaginationResponse<Result<[RecentActivitiesModel]>>) throws {
+        // validate before request.
+        try validateUser()
+        try validateLoggedIn()
+
+        try UserHandler.shared.getRecentActivities(paginationParameters: paginationParameters,
+                                                   updateHandler: updateHandler,
+                                                   completionHandler: completionHandler)
+    }
+    
+    public func getRecentFollowingActivities(paginationParameters: PaginationParameters,
+                                             updateHandler: PaginationResponse<RecentFollowingsActivitiesModel>?,
+                                             completionHandler: @escaping PaginationResponse<Result<[RecentFollowingsActivitiesModel]>>) throws {
+        // validate before request.
+        try validateUser()
+        try validateLoggedIn()
+
+        try UserHandler.shared.getRecentFollowingActivities(paginationParameters: paginationParameters,
+                                                            updateHandler: updateHandler,
+                                                            completionHandler: completionHandler)
+    }
+
+    public func getExploreFeeds(paginationParameters: PaginationParameters,
+                                updateHandler: PaginationResponse<ExploreFeedModel>?,
+                                completionHandler: @escaping PaginationResponse<Result<[ExploreFeedModel]>>) throws {
         // validate before request.
         try validateUser()
         try validateLoggedIn()
         
-        try FeedHandler.shared.getExploreFeeds(paginationParameter: paginationParameter) { (result) in
-            completion(result)
-        }
+        try FeedHandler.shared.getExploreFeeds(paginationParameters: paginationParameters,
+                                               updateHandler: updateHandler,
+                                               completionHandler: completionHandler)
     }
     
-    public func getUserTimeLine(paginationParameter: PaginationParameters, completion: @escaping (Result<[TimeLineModel]>) -> ()) throws {
+    public func getUserTimeLine(paginationParameters: PaginationParameters,
+                                updateHandler: PaginationResponse<TimeLineModel>?,
+                                completionHandler: @escaping PaginationResponse<Result<[TimeLineModel]>>) throws {
         // validate before request.
         try validateUser()
         try validateLoggedIn()
         
-        try FeedHandler.shared.getUserTimeLine(paginationParameter: paginationParameter) { (result) in
-            completion(result)
-        }
+        try FeedHandler.shared.getUserTimeLine(paginationParameters: paginationParameters,
+                                               updateHandler: updateHandler,
+                                               completionHandler: completionHandler)
     }
     
-    public func getUserMedia(for username: String, paginationParameter: PaginationParameters, completion: @escaping (Result<[UserFeedModel]>) -> ()) throws {
+    public func getUserMedia(user: UserReference,
+                             paginationParameters: PaginationParameters,
+                             updateHandler: PaginationResponse<UserFeedModel>?,
+                             completionHandler: @escaping PaginationResponse<Result<[UserFeedModel]>>) throws {
         // validate before request.
         try validateUser()
         try validateLoggedIn()
         
-        try MediaHandler.shared.getUserMedia(for: username, paginationParameter: paginationParameter) { (result) in
-            completion(result)
-        }
-    }
-    
-    /// receive user medias for a single page,
-    /// for first request pass `nil` to `maxId` parameter.
-    public func getUserMedia(userPk: Int, maxId: String?, completion: @escaping (Result<UserFeedModel>, String?) -> ()) throws {
-        try validateUser()
-        try validateLoggedIn()
-        
-        try MediaHandler.shared.getUserMedia(userPk: userPk, maxId: maxId, completion: { (result, maxId) in
-            completion(result, maxId)
-        })
-    }
-    
-    /** Fetching media with pk returns more accurate results */
-    public func getUserMedia(for pk: Int, paginationParameter: PaginationParameters, completion: @escaping (Result<[UserFeedModel]>) -> ()) throws {
-        // validate before request.
-        try validateUser()
-        try validateLoggedIn()
-        
-        try MediaHandler.shared.getUserMedia(for: pk, paginationParameter: paginationParameter) { (result) in
-            completion(result)
-        }
+        try MediaHandler.shared.getUserMedia(user: user,
+                                             paginationParameters: paginationParameters,
+                                             updateHandler: updateHandler,
+                                             completionHandler: completionHandler)
     }
     
     public func getMediaInfo(mediaId: String, completion: @escaping (Result<MediaModel>) -> ()) throws {
@@ -278,36 +272,20 @@ public class APIHandler: APIHandlerProtocol {
         }
     }
     
-    public func getTagFeed(tagName: String, paginationParameter: PaginationParameters, completion: @escaping (Result<[TagFeedModel]>) -> ()) throws {
+    public func getTagFeed(tag: String,
+                           paginationParameters: PaginationParameters,
+                           updateHandler: PaginationResponse<TagFeedModel>?,
+                           completionHandler: @escaping PaginationResponse<Result<[TagFeedModel]>>) throws {
         // validate before request.
         try validateUser()
         try validateLoggedIn()
         
-        try FeedHandler.shared.getTagFeed(tagName: tagName, paginationParameter: paginationParameter) { (result) in
-            completion(result)
-        }
+        try FeedHandler.shared.getTagFeed(tag: tag,
+                                          paginationParameters: paginationParameters,
+                                          updateHandler: updateHandler,
+                                          completionHandler: completionHandler)
     }
-    
-    public func getRecentActivities(paginationParameter: PaginationParameters, completion: @escaping (Result<[RecentActivitiesModel]>) -> ()) throws {
-        // validate before request.
-        try validateUser()
-        try validateLoggedIn()
         
-        try UserHandler.shared.getRecentActivities(paginationParameter: paginationParameter) { (result) in
-            completion(result)
-        }
-    }
-    
-    public func getRecentFollowingActivities(paginationParameter: PaginationParameters, completion: @escaping (Result<[RecentFollowingsActivitiesModel]>) -> ()) throws {
-        // validate before request.
-        try validateUser()
-        try validateLoggedIn()
-        
-        try UserHandler.shared.getRecentFollowingActivities(paginationParameter: paginationParameter) { (result) in
-            completion(result)
-        }
-    }
-    
     public func getDirectInbox(completion: @escaping (Result<DirectInboxModel>) -> ()) throws {
         // validate before request.
         try validateUser()
@@ -418,14 +396,18 @@ public class APIHandler: APIHandlerProtocol {
         })
     }
     
-    public func getMediaComments(mediaId: String, paginationParameter: PaginationParameters, completion: @escaping (Result<[MediaCommentsResponseModel]>) -> ()) throws {
+    public func getMediaComments(mediaId: String,
+                                 paginationParameters: PaginationParameters,
+                                 updateHandler: PaginationResponse<MediaCommentsResponseModel>?,
+                                 completionHandler: @escaping PaginationResponse<Result<[MediaCommentsResponseModel]>>) throws {
         // validate before request.
         try validateUser()
         try validateLoggedIn()
         
-        try CommentHandler.shared.getMediaComments(mediaId: mediaId, paginationParameter: paginationParameter, completion: { (result) in
-            completion(result)
-        })
+        try CommentHandler.shared.getMediaComments(mediaId: mediaId,
+                                                   paginationParameters: paginationParameters,
+                                                   updateHandler: updateHandler,
+                                                   completionHandler: completionHandler)
     }
     
     public func removeFollower(userId: Int, completion: @escaping (Result<FollowResponseModel>) -> ()) throws {
@@ -534,17 +516,7 @@ public class APIHandler: APIHandlerProtocol {
             completion(result)
         })
     }
-    
-    public func getUserTags(userId: Int, paginationParameter: PaginationParameters, completion: @escaping (Result<[UserFeedModel]>) -> ()) throws {
-        // validate before request.
-        try validateUser()
-        try validateLoggedIn()
         
-        try UserHandler.shared.getUserTags(userId: userId, paginationParameter: paginationParameter, completion: { (result) in
-            completion(result)
-        })
-    }
-    
     public func uploadPhoto(photo: InstaPhoto, completion: @escaping (Result<UploadPhotoResponse>) -> ()) throws {
         // validate before request.
         try validateUser()
@@ -775,3 +747,205 @@ public class APIHandler: APIHandlerProtocol {
     }
 }
 
+// MARK: Deprecated and obsoleted.
+public extension APIHandler {
+    @available(*, deprecated, message: "use `getExploreFeeds(paginationParameters:updateHandler:completionHandler:)` instead.")
+    func getExploreFeeds(paginationParameter: PaginationParameters, completion: @escaping (Result<[ExploreFeedModel]>) -> ()) throws {
+        // validate before request.
+        try validateUser()
+        try validateLoggedIn()
+        
+        try FeedHandler.shared.getExploreFeeds(paginationParameters: paginationParameter,
+                                               updateHandler: nil,
+                                               completionHandler: { response, _ in completion(response) })
+    }
+    
+    @available(*, deprecated, message: "use `getTagFeed(tag:paginationParameters:updateHandler:completionHandler:)` instead.")
+    func getTagFeed(tagName: String, paginationParameter: PaginationParameters, completion: @escaping (Result<[TagFeedModel]>) -> ()) throws {
+        // validate before request.
+        try validateUser()
+        try validateLoggedIn()
+        
+        try FeedHandler.shared.getTagFeed(tag: tagName,
+                                          paginationParameters: paginationParameter,
+                                          updateHandler: nil,
+                                          completionHandler: { response, _ in completion(response) })
+    }
+    
+    @available(*, deprecated, message: "use `getUserTimeLine(paginationParameters:updateHandler:completionHandler:)` instead.")
+    func getUserTimeLine(paginationParameter: PaginationParameters, completion: @escaping (Result<[TimeLineModel]>) -> ()) throws {
+        // validate before request.
+        try validateUser()
+        try validateLoggedIn()
+        
+        try FeedHandler.shared.getUserTimeLine(paginationParameters: paginationParameter,
+                                               updateHandler: nil,
+                                               completionHandler: { response, _ in completion(response) })
+    }
+    
+    @available(*, deprecated, message: "use `getMediaComments(mediaId:paginationParameters:updateHandler:completionHandler:)` instead.")
+    func getMediaComments(mediaId: String,
+                                 paginationParameter: PaginationParameters,
+                                 completion: @escaping (Result<[MediaCommentsResponseModel]>) -> ()) throws {
+        // validate before request.
+        try validateUser()
+        try validateLoggedIn()
+        
+        try CommentHandler.shared.getMediaComments(mediaId: mediaId,
+                                                   paginationParameters: paginationParameter,
+                                                   updateHandler: nil,
+                                                   completionHandler: { response, _ in completion(response) })
+    }
+
+    @available(*, deprecated, message: "use `getUserMedia(for:paginationParameters:updateHandler:completionHandler:)` instead.")
+    func getUserMedia(for username: String, paginationParameter: PaginationParameters, completion: @escaping (Result<[UserFeedModel]>) -> ()) throws {
+        // validate before request.
+        try validateUser()
+        try validateLoggedIn()
+        
+        try MediaHandler.shared.getUserMedia(user: .username(username),
+                                             paginationParameters: paginationParameter,
+                                             updateHandler: nil,
+                                             completionHandler: { response, _ in completion(response) })
+    }
+    
+    /// receive user medias for a single page,
+    /// for first request pass `nil` to `maxId` parameter.
+    @available(*, deprecated, message: "use `getUserMedia(user:paginationParameters:updateHandler:completionHandler:)` instead.")
+    func getUserMedia(userPk: Int, maxId: String?, completion: @escaping (Result<UserFeedModel>, String?) -> ()) throws {
+        // validate before request.
+        try validateUser()
+        try validateLoggedIn()
+        
+        try MediaHandler.shared.getUserMedia(user: .pk(userPk),
+                                             paginationParameters: .init(maxId: maxId, maxPagesToLoad: 1),
+                                             updateHandler: { response, parameters in completion(Return.success(value: response), parameters.nextMaxId) },
+                                             completionHandler: { _, _ in })
+    }
+    
+    /** Fetching media with pk returns more accurate results */
+    @available(*, deprecated, message: "use `getUserMedia(user:paginationParameters:updateHandler:completionHandler:)` instead.")
+    func getUserMedia(for pk: Int, paginationParameter: PaginationParameters, completion: @escaping (Result<[UserFeedModel]>) -> ()) throws {
+        // validate before request.
+        try validateUser()
+        try validateLoggedIn()
+        
+        try MediaHandler.shared.getUserMedia(user: .pk(pk),
+                                             paginationParameters: paginationParameter,
+                                             updateHandler: nil,
+                                             completionHandler: { response, _ in completion(response) })
+    }
+    
+    @available(*, deprecated, message: "use `getUserFollowing(user:paginationParameters:updateHandler:completionHandler:)` instead.")
+    func getUserFollowing(username: String, paginationParameter: PaginationParameters, searchQuery: String = "", completion: @escaping (Result<[UserShortModel]>) -> ()) throws {
+        // validate before request.
+        try validateUser()
+        try validateLoggedIn()
+        
+        try UserHandler.shared.getUserFollowing(user: .username(username),
+                                                filteringProfilesMatchingQuery: searchQuery,
+                                                paginationParameters: paginationParameter,
+                                                updateHandler: nil,
+                                                completionHandler: { response, _ in completion(response) })
+    }
+    
+    @available(*, deprecated, message: "use `getUserFollowers(user:paginationParameters:updateHandler:completionHandler:)` instead.")
+    func getUserFollowers(username: String, paginationParameter: PaginationParameters, searchQuery: String, completion: @escaping (Result<[UserShortModel]>) -> ()) throws {
+        // validate before request.
+        try validateUser()
+        try validateLoggedIn()
+        
+        try UserHandler.shared.getUserFollowers(user: .username(username),
+                                                filteringProfilesMatchingQuery: searchQuery,
+                                                paginationParameters: paginationParameter,
+                                                updateHandler: nil,
+                                                completionHandler: { response, _ in completion(response) })
+    }
+    
+    @available(*, deprecated, message: "use `getUserFollowers(user:paginationParameters:updateHandler:completionHandler:)` instead.")
+    /** Searching with Pk returns more accurate results */
+    func getUserFollowers(pk: Int, paginationParameter: PaginationParameters, searchQuery: String, completion: @escaping (Result<[UserShortModel]>) -> ()) throws {
+        // validate before request.
+        try validateUser()
+        try validateLoggedIn()
+        try UserHandler.shared.getUserFollowing(user: .pk(pk),
+                                                filteringProfilesMatchingQuery: searchQuery,
+                                                paginationParameters: paginationParameter,
+                                                updateHandler: nil,
+                                                completionHandler: { response, _ in completion(response) })
+    }
+    
+    @available(*, deprecated, message: "use `getUserFollowers(user:paginationParameters:updateHandler:completionHandler:)` instead.")
+    /// receives followers from single page by passing maxId of page.
+    /// for first request, pass `nil` for `maxId` parameter.
+    func getUserFollowers(userId: Int, maxId: String?, searchQuery: String, completion: @escaping (Result<UserShortListModel>, String?) -> ()) throws {
+        try validateUser()
+        try validateLoggedIn()
+        try UserHandler.shared.getUserFollowers(user: .pk(userId),
+                                                filteringProfilesMatchingQuery: searchQuery,
+                                                paginationParameters: .init(maxId: maxId, maxPagesToLoad: 1),
+                                                updateHandler: { response, parameters in completion(Return.success(value: response), parameters.nextMaxId) },
+                                                completionHandler: { _, _ in })
+    }
+    
+    @available(*, deprecated, message: "use `getUserFollowing(user:paginationParameters:updateHandler:completionHandler:)` instead.")
+    /// receives following from single page by passing maxId of page.
+    /// for first request, pass `nil` for `maxId` parameter.
+    func getUserFollowing(userId: Int, maxId: String?, searchQuery: String, completion: @escaping (Result<UserShortListModel>, String?) -> ()) throws {
+        try validateUser()
+        try validateLoggedIn()
+        try UserHandler.shared.getUserFollowing(user: .pk(userId),
+                                                filteringProfilesMatchingQuery: searchQuery,
+                                                paginationParameters: .init(maxId: maxId, maxPagesToLoad: 1),
+                                                updateHandler: { response, parameters in completion(Return.success(value: response), parameters.nextMaxId) },
+                                                completionHandler: { _, _ in })
+    }
+    
+    @available(*, deprecated, message: "use `getUserFollowing(user:paginationParameters:updateHandler:completionHandler:)` instead.")
+    /** Searching with Pk returns more accurate results */
+    func getUserFollowing(pk: Int, paginationParameter: PaginationParameters, searchQuery: String, completion: @escaping (Result<[UserShortModel]>) -> ()) throws {
+        // validate before request.
+        try validateUser()
+        try validateLoggedIn()
+
+        try UserHandler.shared.getUserFollowers(user: .pk(pk),
+                                                filteringProfilesMatchingQuery: searchQuery,
+                                                paginationParameters: paginationParameter,
+                                                updateHandler: nil,
+                                                completionHandler: { response, _ in completion(response) })
+    }
+    
+    @available(*, deprecated, message: "use `getRecentActivities(paginationParameters:updateHandler:completionHandler:)` instead.")
+    func getRecentActivities(paginationParameter: PaginationParameters, completion: @escaping (Result<[RecentActivitiesModel]>) -> ()) throws {
+        // validate before request.
+        try validateUser()
+        try validateLoggedIn()
+        
+        try UserHandler.shared.getRecentActivities(paginationParameters: paginationParameter,
+                                                   updateHandler: nil,
+                                                   completionHandler: { response, _ in completion(response) })
+    }
+    
+    @available(*, deprecated, message: "use `getRecentFollowingActivities(paginationParameters:updateHandler:completionHandler:)` instead.")
+    func getRecentFollowingActivities(paginationParameter: PaginationParameters, completion: @escaping (Result<[RecentFollowingsActivitiesModel]>) -> ()) throws {
+        // validate before request.
+        try validateUser()
+        try validateLoggedIn()
+        
+        try UserHandler.shared.getRecentFollowingActivities(paginationParameters: paginationParameter,
+                                                            updateHandler: nil,
+                                                            completionHandler: { response, _ in completion(response) })
+    }
+    
+    @available(*, deprecated, message: "use `getUserTags(user:paginationParameters:updateHandler:completionHandler:)` instead.")
+    func getUserTags(userId: Int, paginationParameter: PaginationParameters, completion: @escaping (Result<[UserFeedModel]>) -> ()) throws {
+        // validate before request.
+        try validateUser()
+        try validateLoggedIn()
+        
+        try UserHandler.shared.getUserTags(user: .pk(userId),
+                                           paginationParameters: paginationParameter,
+                                           updateHandler: nil,
+                                           completionHandler: { response, _ in completion(response) })
+    }
+}

--- a/SwiftyInsta/API/Services/APIHandler.swift
+++ b/SwiftyInsta/API/Services/APIHandler.swift
@@ -745,10 +745,8 @@ public class APIHandler: APIHandlerProtocol {
             throw CustomErrors.runTimeError("empty request message.")
         }
     }
-}
 
-// MARK: Deprecated and obsoleted.
-public extension APIHandler {
+    // MARK: Deprecated and obsoleted.
     @available(*, deprecated, message: "use `getExploreFeeds(paginationParameters:updateHandler:completionHandler:)` instead.")
     func getExploreFeeds(paginationParameter: PaginationParameters, completion: @escaping (Result<[ExploreFeedModel]>) -> ()) throws {
         // validate before request.
@@ -818,7 +816,7 @@ public extension APIHandler {
         try validateLoggedIn()
         
         try MediaHandler.shared.getUserMedia(user: .pk(userPk),
-                                             paginationParameters: .init(maxId: maxId, maxPagesToLoad: 1),
+                                             paginationParameters: .init(startingAt: maxId, maxPagesToLoad: 1),
                                              updateHandler: { response, parameters in completion(Return.success(value: response), parameters.nextMaxId) },
                                              completionHandler: { _, _ in })
     }
@@ -883,7 +881,7 @@ public extension APIHandler {
         try validateLoggedIn()
         try UserHandler.shared.getUserFollowers(user: .pk(userId),
                                                 filteringProfilesMatchingQuery: searchQuery,
-                                                paginationParameters: .init(maxId: maxId, maxPagesToLoad: 1),
+                                                paginationParameters: .init(startingAt: maxId, maxPagesToLoad: 1),
                                                 updateHandler: { response, parameters in completion(Return.success(value: response), parameters.nextMaxId) },
                                                 completionHandler: { _, _ in })
     }
@@ -896,7 +894,7 @@ public extension APIHandler {
         try validateLoggedIn()
         try UserHandler.shared.getUserFollowing(user: .pk(userId),
                                                 filteringProfilesMatchingQuery: searchQuery,
-                                                paginationParameters: .init(maxId: maxId, maxPagesToLoad: 1),
+                                                paginationParameters: .init(startingAt: maxId, maxPagesToLoad: 1),
                                                 updateHandler: { response, parameters in completion(Return.success(value: response), parameters.nextMaxId) },
                                                 completionHandler: { _, _ in })
     }

--- a/SwiftyInsta/API/Services/FeedHandler.swift
+++ b/SwiftyInsta/API/Services/FeedHandler.swift
@@ -1,163 +1,61 @@
 //
 //  FeedHandler.swift
-//  SwiftyInsta
 //
-//  Created by Mahdi Makhdumi on 11/23/18.
+//  Modified by Stefano Bertagno on 11/21/19.
 //  Copyright © 2018 Mahdi. All rights reserved.
 //
 
 import Foundation
 
 public protocol FeedHandlerProtocol {
-    func getExploreFeeds(paginationParameter: PaginationParameters, completion: @escaping (Result<[ExploreFeedModel]>) -> ()) throws
-    func getTagFeed(tagName: String, paginationParameter: PaginationParameters, completion: @escaping (Result<[TagFeedModel]>) -> ()) throws
-    func getUserTimeLine(paginationParameter: PaginationParameters, completion: @escaping (Result<[TimeLineModel]>) -> ()) throws
+    func getExploreFeeds(paginationParameters: PaginationParameters,
+                         updateHandler: PaginationResponse<ExploreFeedModel>?,
+                         completionHandler: @escaping PaginationResponse<Result<[ExploreFeedModel]>>) throws
+    func getTagFeed(tag: String,
+                    paginationParameters: PaginationParameters,
+                    updateHandler: PaginationResponse<TagFeedModel>?,
+                    completionHandler: @escaping PaginationResponse<Result<[TagFeedModel]>>) throws
+    func getUserTimeLine(paginationParameters: PaginationParameters,
+                         updateHandler: PaginationResponse<TimeLineModel>?,
+                         completionHandler: @escaping PaginationResponse<Result<[TimeLineModel]>>) throws
 }
 
 class FeedHandler: FeedHandlerProtocol {
     static let shared = FeedHandler()
     
+    // MARK: Private
     private init() {
-        
-    }
-    
-    func getExploreFeeds(paginationParameter: PaginationParameters, completion: @escaping (Result<[ExploreFeedModel]>) -> ()) throws {
-        getExploreList(from: try URLs.getExploreFeedUrl(), exploreList: [], paginationParameter: paginationParameter) { (list) in
-            completion(Return.success(value: list))
-        }
-    }
-    
-    fileprivate func getExploreList(from url: URL, exploreList: [ExploreFeedModel], paginationParameter: PaginationParameters, completion: @escaping ([ExploreFeedModel]) -> ()) {
-        if paginationParameter.pagesLoaded == paginationParameter.maxPagesToLoad {
-            completion(exploreList)
-        } else {
-            var _paginationParameter = paginationParameter
-            _paginationParameter.pagesLoaded += 1
-            var list = exploreList
-            guard let httpHelper = HandlerSettings.shared.httpHelper else {return}
-            httpHelper.sendAsync(method: .get, url: url, body: [:], header: [:]) { [weak self] (data, response, error) in
-                if error != nil {
-                    completion(list)
-                } else {
-                    if response?.statusCode != 200 {
-                        completion(list)
-                    } else {
-                        if let data = data {
-                            let decoder = JSONDecoder()
-                            decoder.keyDecodingStrategy = .convertFromSnakeCase
-                            do {
-                                let newItems = try decoder.decode(ExploreFeedModel.self, from: data)
-                                list.append(newItems)
-                                if newItems.moreAvailable! {
-                                    _paginationParameter.nextId = newItems.nextMaxId!
-                                    let url = try URLs.getExploreFeedUrl(maxId: _paginationParameter.nextId)
-                                    self?.getExploreList(from: url, exploreList: list, paginationParameter: _paginationParameter, completion: { (result) in
-                                        completion(result)
-                                    })
-                                } else {
-                                    completion(list)
-                                }
-                            } catch {
-                                completion(list)
-                            }
-                        } else {
-                            completion(list)
-                        }
-                    }
-                }
-            }
-        }
-    }
-    
-    func getTagFeed(tagName: String, paginationParameter: PaginationParameters, completion: @escaping (Result<[TagFeedModel]>) -> ()) throws {
-        getTagList(for: try URLs.getTagFeed(for: tagName), tag: tagName, list: [], paginationParameter: paginationParameter) { (value) in
-            completion(Return.success(value: value))
-        }
     }
 
-    fileprivate func getTagList(for url: URL, tag: String, list: [TagFeedModel], paginationParameter: PaginationParameters, completion: @escaping ([TagFeedModel]) -> ()) {
-        if paginationParameter.pagesLoaded == paginationParameter.maxPagesToLoad {
-            completion(list)
-        } else {
-            var _paginationParameter = paginationParameter
-            _paginationParameter.pagesLoaded += 1
-            
-            guard let httpHelper = HandlerSettings.shared.httpHelper else {return}
-            httpHelper.sendAsync(method: .get, url: url, body: [:], header: [:]) { [weak self] (data, response, error) in
-                if error != nil {
-                    completion(list)
-                } else {
-                    if let data = data {
-                        let decoder = JSONDecoder()
-                        decoder.keyDecodingStrategy = .convertFromSnakeCase
-                        do {
-                            var tagList = list
-                            let newItems = try decoder.decode(TagFeedModel.self, from: data)
-                            tagList.append(newItems)
-                            if newItems.moreAvailable! {
-                                _paginationParameter.nextId = newItems.nextMaxId!
-                                let url = try! URLs.getTagFeed(for: tag, maxId: _paginationParameter.nextId)
-                                self!.getTagList(for: url, tag: tag, list: tagList, paginationParameter: _paginationParameter, completion: { (result) in
-                                    completion(result)
-                                })
-                            } else {
-                                completion(tagList)
-                            }
-                        } catch {
-                            completion(list)
-                        }
-                    } else {
-                        completion(list)
-                    }
-                }
-            }
-        }
+    // MARK: Protocol conformacy
+    public func getExploreFeeds(paginationParameters: PaginationParameters,
+                                updateHandler: PaginationResponse<ExploreFeedModel>?,
+                                completionHandler: @escaping PaginationResponse<Result<[ExploreFeedModel]>>) throws {
+        PaginationHandler.getPages(ExploreFeedModel.self,
+                                   for: paginationParameters,
+                                   at: { try URLs.getExploreFeedUrl(maxId: $0.nextMaxId ?? "") },
+                                   updateHandler: updateHandler,
+                                   completionHandler: completionHandler)
     }
     
-    func getUserTimeLine(paginationParameter: PaginationParameters, completion: @escaping (Result<[TimeLineModel]>) -> ()) throws {
-        getTimeLineList(from: try URLs.getUserTimeLineUrl(), list: [], paginationParameter: paginationParameter) { (list) in
-            completion(Return.success(value: list))        }
+    func getTagFeed(tag: String,
+                    paginationParameters: PaginationParameters,
+                    updateHandler: PaginationResponse<TagFeedModel>?,
+                    completionHandler: @escaping PaginationResponse<Result<[TagFeedModel]>>) throws {
+        PaginationHandler.getPages(TagFeedModel.self,
+                                   for: paginationParameters,
+                                   at: { try URLs.getTagFeed(for: tag, maxId: $0.nextMaxId ?? "") },
+                                   updateHandler: updateHandler,
+                                   completionHandler: completionHandler)
     }
     
-    fileprivate func getTimeLineList(from url: URL, list: [TimeLineModel], paginationParameter: PaginationParameters, completion: @escaping ([TimeLineModel]) -> ()) {
-        if paginationParameter.pagesLoaded == paginationParameter.maxPagesToLoad {
-            completion(list)
-        } else {
-            var _paginationParameter = paginationParameter
-            _paginationParameter.pagesLoaded += 1
-            var timelineList = list
-            guard let httpHelper = HandlerSettings.shared.httpHelper else {return}
-            httpHelper.sendAsync(method: .post, url: url, body: [:], header: [:]) { [weak self] (data, response, error) in
-                if error != nil {
-                    completion(timelineList)
-                } else {
-                    if response?.statusCode != 200 {
-                        completion(timelineList)
-                    } else {
-                        if let data = data {
-                            let decoder = JSONDecoder()
-                            decoder.keyDecodingStrategy = .convertFromSnakeCase
-                            do {
-                                let newItems = try decoder.decode(TimeLineModel.self, from: data)
-                                timelineList.append(newItems)
-                                if newItems.moreAvailable! {
-                                    _paginationParameter.nextId = newItems.nextMaxId!
-                                    let url = try URLs.getUserTimeLineUrl(maxId: _paginationParameter.nextId)
-                                    self!.getTimeLineList(from: url, list: timelineList, paginationParameter: _paginationParameter, completion: { (result) in
-                                        completion(result)
-                                    })
-                                } else {
-                                    completion(timelineList)
-                                }
-                            } catch {
-                                completion(timelineList)
-                            }
-                        } else {
-                            completion(timelineList)
-                        }
-                    }
-                }
-            }
-        }
+    func getUserTimeLine(paginationParameters: PaginationParameters,
+                         updateHandler: PaginationResponse<TimeLineModel>?,
+                         completionHandler: @escaping PaginationResponse<Result<[TimeLineModel]>>) throws {
+        PaginationHandler.getPages(TimeLineModel.self,
+                                   for: paginationParameters,
+                                   at: { try URLs.getUserTimeLineUrl(maxId: $0.nextMaxId ?? "") },
+                                   updateHandler: updateHandler,
+                                   completionHandler: completionHandler)
     }
 }

--- a/SwiftyInsta/API/Services/PaginationHandler.swift
+++ b/SwiftyInsta/API/Services/PaginationHandler.swift
@@ -83,7 +83,7 @@ struct PaginationHandler {
                                     }
                                     // load more.
                                     paginationParamaters.nextMaxId = model.nextMaxId.flatMap { String($0) }
-                                    guard paginationParamaters.nextMaxId != nil else {
+                                    guard !(paginationParamaters.nextMaxId ?? "").isEmpty else {
                                         return completionHandler(Return.success(value: fetched), paginationParamaters)
                                     }
                                     getPage()

--- a/SwiftyInsta/API/Services/PaginationHandler.swift
+++ b/SwiftyInsta/API/Services/PaginationHandler.swift
@@ -60,7 +60,7 @@ struct PaginationHandler {
                               url: endpoint,
                               body: [:],
                               header: [:]) { data, response, error in
-                                guard error != nil else {
+                                guard error == nil else {
                                     completionHandler(Return.fail(error: error, response: .fail, value: fetched), paginationParamaters)
                                     return
                                 }

--- a/SwiftyInsta/API/Services/PaginationHandler.swift
+++ b/SwiftyInsta/API/Services/PaginationHandler.swift
@@ -82,7 +82,7 @@ struct PaginationHandler {
                                         return completionHandler(Return.success(value: fetched), paginationParamaters)
                                     }
                                     // load more.
-                                    paginationParamaters.nextMaxId = model.nextMaxId.flatMap { String($0) } ?? ""
+                                    paginationParamaters.nextMaxId = model.nextMaxId.flatMap { String($0) }
                                     guard paginationParamaters.nextMaxId != nil else {
                                         return completionHandler(Return.success(value: fetched), paginationParamaters)
                                     }

--- a/SwiftyInsta/API/Services/PaginationHandler.swift
+++ b/SwiftyInsta/API/Services/PaginationHandler.swift
@@ -1,0 +1,99 @@
+//
+//  PaginationHandler.swift
+//  SwiftyInsta
+//
+//  Created by Stefano Bertagno on 07/19/2019.
+//  Copyright © 2019 Mahdi. All rights reserved.
+//
+
+import Foundation
+
+public protocol PaginationProtocol {
+    associatedtype Id: Hashable & LosslessStringConvertible
+    var autoLoadMoreEnabled: Bool? { get }
+    var moreAvailable: Bool? { get }
+    var nextMaxId: Id? { get }
+    var numResults: Int? { get }
+}
+public extension PaginationProtocol {
+    var autoLoadMoreEnabled: Bool? { return nil }
+    var moreAvailable: Bool? { return nil }
+    var numResults: Int? { return nil }
+}
+
+public protocol NestedPaginationProtocol: PaginationProtocol {
+    static var nextMaxIdPath: KeyPath<Self, Id?> { get }
+}
+public extension NestedPaginationProtocol {
+    var nextMaxId: Id? { return self[keyPath: Self.nextMaxIdPath] }
+}
+
+struct PaginationHandler {
+    /// Get all pages matching criteria.
+    static func getPages<M>(_ result: M.Type,
+                            for paginationParamaters: PaginationParameters,
+                            at url: @escaping (PaginationParameters) throws -> URL,
+                            updateHandler: PaginationResponse<M>?,
+                            completionHandler: @escaping PaginationResponse<Result<[M]>>) where M: Decodable & PaginationProtocol {
+        // check for valid pagination.
+        guard paginationParamaters.canLoadMore, let handler = HandlerSettings.shared.httpHelper else {
+            return completionHandler(Return.fail(error: nil, response: .fail, value: nil), paginationParamaters)
+        }
+        // to be populated with fetched data, but currently empty.
+        var fetched: [M] = []
+        
+        // declare nested function to load current page.
+        func getPage() {
+            // obtain url.
+            let endpoint: URL!
+            do {
+                endpoint = try url(paginationParamaters)
+            } catch {
+                completionHandler(Return.fail(error: error,
+                                              response: fetched.isEmpty ? .ok : .fail,
+                                              value: fetched),
+                                   paginationParamaters)
+                return
+            }
+            // fetch values.
+            handler.sendAsync(method: .get,
+                              url: endpoint,
+                              body: [:],
+                              header: [:]) { data, response, error in
+                                guard error != nil else {
+                                    completionHandler(Return.fail(error: error, response: .fail, value: fetched), paginationParamaters)
+                                    return
+                                }
+                                guard let response = response, response.statusCode == 200, let data = data else {
+                                    completionHandler(Return.fail(error: nil, response: .ok, value: fetched), paginationParamaters)
+                                    return
+                                }
+                                // we loaded one more page.
+                                paginationParamaters.loadedPages += 1
+                                // decode response.
+                                let decoder = JSONDecoder()
+                                decoder.keyDecodingStrategy = .convertFromSnakeCase
+                                do {
+                                    let model = try decoder.decode(M.self, from: data)
+                                    // append to model and ask for next.
+                                    updateHandler?(model, paginationParamaters)
+                                    fetched.append(model)
+                                    guard paginationParamaters.canLoadMore else {
+                                        return completionHandler(Return.success(value: fetched), paginationParamaters)
+                                    }
+                                    // load more.
+                                    paginationParamaters.nextMaxId = model.nextMaxId.flatMap { String($0) } ?? ""
+                                    guard paginationParamaters.nextMaxId != nil else {
+                                        return completionHandler(Return.success(value: fetched), paginationParamaters)
+                                    }
+                                    getPage()
+                                } catch {
+                                    completionHandler(Return.fail(error: error, response: .ok, value: fetched), paginationParamaters)
+                                }
+                                
+            }
+        }
+        // exhaust pages.
+        getPage()
+    }
+}

--- a/SwiftyInsta/Classes/Models/CommentModel.swift
+++ b/SwiftyInsta/Classes/Models/CommentModel.swift
@@ -33,7 +33,7 @@ public struct CommentModel: Codable {
     }
 }
 
-public struct MediaCommentsResponseModel: Codable, BaseStatusResponseProtocol {
+public struct MediaCommentsResponseModel: Codable, PaginationProtocol, BaseStatusResponseProtocol {
     public var commentLikesEnabled: Bool?
     public var comments: [CommentModel]?
     public var commentCount: Int?

--- a/SwiftyInsta/Classes/Models/ExploreFeedModel.swift
+++ b/SwiftyInsta/Classes/Models/ExploreFeedModel.swift
@@ -8,14 +8,7 @@
 
 import Foundation
 
-protocol FeedProtocol {
-    var autoLoadMoreEnabled: Bool? {get}
-    var moreAvailable: Bool? {get}
-    var nextMaxId: String? {get}
-    var numResults: Int? {get}
-}
-
-public struct ExploreFeedModel: Codable, FeedProtocol, BaseStatusResponseProtocol {
+public struct ExploreFeedModel: Codable, PaginationProtocol, BaseStatusResponseProtocol {
     public var rankToken: String?
     public var autoLoadMoreEnabled: Bool?
     public var moreAvailable: Bool?

--- a/SwiftyInsta/Classes/Models/PaginationParameters.swift
+++ b/SwiftyInsta/Classes/Models/PaginationParameters.swift
@@ -20,12 +20,12 @@ public class PaginationParameters {
     public var canLoadMore: Bool { return loadedPages < maxPagesToLoad }
         
     // MARK: Init
-    public init(maxId: String? = nil, maxPagesToLoad: Int = 1) {
+    public init(startingAt maxId: String? = nil, maxPagesToLoad: Int = 1) {
         precondition(maxPagesToLoad > 0, "`maxPagesToLoad` must be bigger than `0`.")
         self.nextMaxId = maxId
         self.maxPagesToLoad = maxPagesToLoad
     }
-    public static let everything = PaginationParameters(maxId: nil, maxPagesToLoad: .max)
+    public static let everything = PaginationParameters(startingAt: nil, maxPagesToLoad: .max)
         
     // MARK: Obsolete
     @available(*, unavailable, message: "use `init` instead.")

--- a/SwiftyInsta/Classes/Models/PaginationParameters.swift
+++ b/SwiftyInsta/Classes/Models/PaginationParameters.swift
@@ -2,22 +2,36 @@
 //  PaginationParameters.swift
 //  SwiftyInsta
 //
-//  Created by Mahdi on 11/3/18.
+//  Modified by Stefano Bertagno on 11/3/18.
 //  Copyright © 2018 Mahdi. All rights reserved.
 //
 
 import Foundation
 
-public struct PaginationParameters {
-    public var maxPagesToLoad: Int = Int.max
-    public var pagesLoaded: Int = 0
-    public var nextId = ""
+public class PaginationParameters {
+    /// The maximum number of pages to load. Defaults to `1`.
+    public var maxPagesToLoad: Int
+    /// The number of pages already loaded. Defaults to `0`.
+    public var loadedPages: Int = 0
+    /// The next `maxId`. Defaults to `nil`.
+    public var nextMaxId: String?
     
-    private init(maxPages: Int) {
-        maxPagesToLoad = maxPages
+    /// Whether there's something left to load.
+    public var canLoadMore: Bool { return loadedPages < maxPagesToLoad }
+        
+    // MARK: Init
+    public init(maxId: String? = nil, maxPagesToLoad: Int = 1) {
+        precondition(maxPagesToLoad > 0, "`maxPagesToLoad` must be bigger than `0`.")
+        self.nextMaxId = maxId
+        self.maxPagesToLoad = maxPagesToLoad
     }
-    
+    public static let everything = PaginationParameters(maxId: nil, maxPagesToLoad: .max)
+        
+    // MARK: Obsolete
+    @available(*, unavailable, message: "use `init` instead.")
     public static func maxPagesToLoad(maxPages: Int) -> PaginationParameters {
-        return PaginationParameters(maxPages: maxPages)
+        fatalError("`maxPagesToLoad(maxPages:)` was removed.")
     }
 }
+
+public typealias PaginationResponse<R> = (_ response: R, _ parameters: PaginationParameters) -> Void

--- a/SwiftyInsta/Classes/Models/RecentActivitiesModel.swift
+++ b/SwiftyInsta/Classes/Models/RecentActivitiesModel.swift
@@ -8,7 +8,9 @@
 
 import Foundation
 
-public struct RecentActivitiesModel: Codable, BaseStatusResponseProtocol {
+public struct RecentActivitiesModel: Codable, BaseStatusResponseProtocol, NestedPaginationProtocol {
+    public typealias Id = String
+    public static let nextMaxIdPath: KeyPath<RecentActivitiesModel, Id?> = \RecentActivitiesModel.aymf?.nextMaxId
     public var aymf: AymfItemModel?
     public var counts: CountsModel?
     public var friendRequestStories: [RecentActivityStoryModel]?
@@ -28,7 +30,7 @@ public struct RecentActivitiesModel: Codable, BaseStatusResponseProtocol {
     }
 }
 
-public struct RecentFollowingsActivitiesModel: Codable, BaseStatusResponseProtocol {
+public struct RecentFollowingsActivitiesModel: Codable, BaseStatusResponseProtocol, PaginationProtocol {
     public var autoLoadMoreEnabled: Bool?
     public var nextMaxId: Int?
     public var status: String?
@@ -42,7 +44,7 @@ public struct RecentFollowingsActivitiesModel: Codable, BaseStatusResponseProtoc
     }
 }
 
-public struct AymfItemModel: Codable, FeedProtocol {
+public struct AymfItemModel: Codable, PaginationProtocol {
     public var autoLoadMoreEnabled: Bool?
     public var moreAvailable: Bool?
     public var nextMaxId: String?

--- a/SwiftyInsta/Classes/Models/TagFeedModel.swift
+++ b/SwiftyInsta/Classes/Models/TagFeedModel.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TagFeedModel: Codable, FeedProtocol, BaseStatusResponseProtocol {
+public struct TagFeedModel: Codable, PaginationProtocol, BaseStatusResponseProtocol {
     public var autoLoadMoreEnabled: Bool?
     public var moreAvailable: Bool?
     public var nextMaxId: String?

--- a/SwiftyInsta/Classes/Models/TimeLineModel.swift
+++ b/SwiftyInsta/Classes/Models/TimeLineModel.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TimeLineModel: Codable, FeedProtocol, BaseStatusResponseProtocol {
+public struct TimeLineModel: Codable, PaginationProtocol, BaseStatusResponseProtocol {
     public var autoLoadMoreEnabled: Bool?
     public var moreAvailable: Bool?
     public var nextMaxId: String?

--- a/SwiftyInsta/Classes/Models/UserFeedModel.swift
+++ b/SwiftyInsta/Classes/Models/UserFeedModel.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct UserFeedModel: Codable, FeedProtocol {
+public struct UserFeedModel: Codable, PaginationProtocol {
     public var autoLoadMoreEnabled: Bool?
     public var moreAvailable: Bool?
     public var nextMaxId: String?

--- a/SwiftyInsta/Classes/Models/UserShortListModel.swift
+++ b/SwiftyInsta/Classes/Models/UserShortListModel.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct UserShortListModel: Codable, BaseStatusResponseProtocol {
+public struct UserShortListModel: Codable, BaseStatusResponseProtocol, PaginationProtocol {
     public var status: String?
     public var nextMaxId: String? = ""
     public var bigList: Bool?

--- a/SwiftyInstaTests/SwiftyInstaTests.swift
+++ b/SwiftyInstaTests/SwiftyInstaTests.swift
@@ -193,7 +193,7 @@ class SwiftyInstaTests: XCTestCase {
         do {
             try handler.searchUser(username: username, completion: { (result) in
                 if result.isSucceeded {
-                    result.value?.compactMap { print("username: ", $0.username )}
+                    result.value?.forEach { print("username: ", $0.username as Any) }
                 }
                 
                 exp.fulfill()
@@ -260,7 +260,11 @@ class SwiftyInstaTests: XCTestCase {
     func testGetUserFollowing(handler: APIHandlerProtocol) {
         let exp = expectation(description: "getUserFollowing() faild during timeout")
         do {
-            try handler.getUserFollowing(username: "mehdi.makhdumi", paginationParameter: PaginationParameters.maxPagesToLoad(maxPages: 1), searchQuery: "", completion: { (result) in
+            try handler.getUserFollowing(user: .username("swiftyinsta"),
+                                         filteringProfilesMatchingQuery: nil,
+                                         paginationParameters: .init(startingAt: nil, maxPagesToLoad: 15),
+                                         updateHandler: nil,
+                                         completionHandler: { result, _ in
                 if result.isSucceeded {
                     guard let following = result.value else { return }
                     print("[+] following count: \(following.count)")
@@ -288,7 +292,11 @@ class SwiftyInstaTests: XCTestCase {
     func testGetUserFollowers(handler: APIHandlerProtocol) {
         let exp = expectation(description: "getUserFollowing() faild during timeout")
         do {
-            try handler.getUserFollowers(username: "swiftyinsta", paginationParameter: PaginationParameters.maxPagesToLoad(maxPages: 15), searchQuery: "", completion: { (result) in
+            try handler.getUserFollowers(user: .username("swiftyinsta"),
+                                         filteringProfilesMatchingQuery: nil,
+                                         paginationParameters: .init(startingAt: nil, maxPagesToLoad: 15),
+                                         updateHandler: nil,
+                                         completionHandler: { result, _ in
                 if result.isSucceeded {
                     guard let followers = result.value else { return }
                     print("[+] followers count: \(followers.count)")
@@ -506,7 +514,10 @@ class SwiftyInstaTests: XCTestCase {
         do {
             try handler.getUser(username: userToGetTags, completion: { (user) in
                 if user.isSucceeded {
-                    try? handler.getUserTags(userId: user.value!.pk!, paginationParameter: PaginationParameters.maxPagesToLoad(maxPages: 5), completion: { (result) in
+                    try? handler.getUserTags(user: .pk(user.value?.pk ?? -1),
+                                             paginationParameters: .init(startingAt: nil, maxPagesToLoad: 5),
+                                             updateHandler: nil,
+                                             completionHandler: { result, _ in
                         if result.isSucceeded {
                             print("[+] first page items: \(result.value!.first!.totalCount!)")
                         }
@@ -536,14 +547,16 @@ class SwiftyInstaTests: XCTestCase {
     func testGetExploreFeed(handler: APIHandlerProtocol) {
         let exp = expectation(description: "getExploreFeed() faild during timeout")
         do {
-            try handler.getExploreFeeds(paginationParameter: PaginationParameters.maxPagesToLoad(maxPages: 5)) { (result) in
+            try handler.getExploreFeeds(paginationParameters: .init(startingAt: nil, maxPagesToLoad: 5),
+                                        updateHandler: nil,
+                                        completionHandler: { result, _ in
                 if result.isSucceeded {
                     print("[+] Data received.")
                 } else {
                     print("[-] \(result.info)")
                 }
                 exp.fulfill()
-            }
+            })
         } catch {
             print("[-] \(error.localizedDescription)")
             exp.fulfill()
@@ -563,7 +576,10 @@ class SwiftyInstaTests: XCTestCase {
     func testGetTagFeed(handler: APIHandlerProtocol, tag: String) {
         let exp = expectation(description: "getTagFeed() faild during timeout")
         do {
-            try handler.getTagFeed(tagName: tag, paginationParameter: PaginationParameters.maxPagesToLoad(maxPages: 5), completion: { (result) in
+            try handler.getTagFeed(tag: tag,
+                                   paginationParameters: .init(startingAt: nil, maxPagesToLoad: 5),
+                                   updateHandler: nil,
+                                   completionHandler: { result, _ in
                 if result.isSucceeded {
                     print("[+] first username of each page who used this tagname:")
                     _ = result.value!.map { print("[+] \($0.items!.first!.caption!.user!.fullName!)") }
@@ -589,7 +605,8 @@ class SwiftyInstaTests: XCTestCase {
     func testGetUserTimeLine(handler: APIHandlerProtocol) {
         let exp = expectation(description: "getTimeLine() faild during timeout")
         do {
-            try handler.getUserTimeLine(paginationParameter: PaginationParameters.maxPagesToLoad(maxPages: 5)) { (result) in
+            try handler.getUserTimeLine(paginationParameters: .init(startingAt: nil, maxPagesToLoad: 5),
+                                        updateHandler: nil) { result, _ in
                 if result.isSucceeded {
                     print("[+] Data received.")
                 } else {
@@ -619,13 +636,16 @@ class SwiftyInstaTests: XCTestCase {
     func testGetUserMedia(handler: APIHandlerProtocol) {
         let exp = expectation(description: "getUserMedia() faild during timeout")
         do {
-            try handler.getUserMedia(for: "swiftyinsta", paginationParameter: PaginationParameters.maxPagesToLoad(maxPages: 1)) { (result) in
+            try handler.getUserMedia(user: .username("swiftyinsta"),
+                                     paginationParameters: .init(startingAt: nil, maxPagesToLoad: 5),
+                                     updateHandler: nil,
+                                     completionHandler: { result, _ in
                 if result.isSucceeded {
                     print(result.value!)
                     print("[+] number of pages that include medias: \(result.value!.count)")
                 }
                 exp.fulfill()
-            }
+            })
         } catch {
             print("[-] \(error.localizedDescription)")
             exp.fulfill()
@@ -670,12 +690,14 @@ class SwiftyInstaTests: XCTestCase {
     func testGetRecentActivities(handler: APIHandlerProtocol) {
         let exp = expectation(description: "getRecentActivities() faild during timeout")
         do {
-            try handler.getRecentFollowingActivities(paginationParameter: PaginationParameters.maxPagesToLoad(maxPages: 5)) { (result) in
+            try handler.getRecentActivities(paginationParameters: .init(startingAt: nil, maxPagesToLoad: 5),
+                                            updateHandler: nil,
+                                            completionHandler: { result, _ in
                 if result.isSucceeded {
                     print("[+] \(result.value!)")
                 }
                 exp.fulfill()
-            }
+            })
         } catch {
             print(error.localizedDescription)
             exp.fulfill()
@@ -695,12 +717,14 @@ class SwiftyInstaTests: XCTestCase {
     func testGetRecentFollowingActivities(handler: APIHandlerProtocol) {
         let exp = expectation(description: "getRecentFollowingActivities() faild during timeout")
         do {
-            try handler.getRecentFollowingActivities(paginationParameter: PaginationParameters.maxPagesToLoad(maxPages: 5)) { (result) in
+            try handler.getRecentFollowingActivities(paginationParameters: .init(startingAt: nil, maxPagesToLoad: 5),
+                                                     updateHandler: nil,
+                                                     completionHandler: { result, _ in
                 if result.isSucceeded {
                     print("[+] \(result.value!)")
                 }
                 exp.fulfill()
-            }
+            })
         } catch {
             print(error.localizedDescription)
             exp.fulfill()
@@ -1037,13 +1061,14 @@ class SwiftyInstaTests: XCTestCase {
         let mediaId = "2027973562639689483_8766457680"
         let exp = expectation(description: "likeMedia() faild during timeout")
         do {
-            try handler.getMediaComments(mediaId: mediaId, paginationParameter:  PaginationParameters.maxPagesToLoad(maxPages: 5), completion: { (result) in
-                //print("[+] first comment: \(result.value!.first!.comments!.first!)")
-                let commentId = result.value!.first!.comments!.first!.pk!
-                try! handler.reportComment(mediaId: mediaId, commentId: String(commentId), completion: { (result) in
-                    print(result)
-                    exp.fulfill()
-                })
+            try handler.getMediaComments(mediaId: mediaId,
+                                         paginationParameters: .init(startingAt: nil, maxPagesToLoad: 5),
+                                         updateHandler: { newPage, _ in print(newPage) },
+                                         completionHandler: { result, _ in
+                                            guard let commentId = result.value?.first?.comments?.first?.pk else { return }
+                                            try? handler.reportComment(mediaId: mediaId,
+                                                                       commentId: String(commentId),
+                                                                       completion: { print($0); exp.fulfill() })
             })
         } catch {
             print("[-] \(error.localizedDescription)")
@@ -1337,7 +1362,7 @@ class SwiftyInstaTests: XCTestCase {
         
         try! handler.getStoryHighlights(userPk: userPk, completion: { (result) in
             if result.isSucceeded {
-                print("number of highlights: ", result.value?.tray.count)
+                print("number of highlights: ", result.value?.tray.count as Any)
             }
             
             exp.fulfill()


### PR DESCRIPTION
I've worked on all methods accepting pagination parameters and uniformed them, resulting in shorter and more readable code and a finer tuning and control over the actual endpoint requests (you can both select a starting `maxId` and how many pages to load, and get notified through both `updateHandler`, every time a new page is fetched, and `completionHandler`).

I've kept all previous methods in `APIHandler` and simply deprecated them.
However they're not immediately accessible to `APIHandlerProtocol` (they're no longer members of the individual protocols), which is pretty disruptive (definitely a`1.7`, not a `1.6.*`), but #47 showed me how much it was needed (it was pretty messy 😊).

(Bonus: a single method for both accessories requiring either `pk` or `username`, through `enum UserReference`, with `.pk(Int)` and `.username(String)`)