### PR TITLE
Fix `info(for:completionHandler:)` decoding type

### DIFF
--- a/SwiftyInsta/API/Services/MediaHandler.swift
+++ b/SwiftyInsta/API/Services/MediaHandler.swift
@@ -43,8 +43,8 @@ public class MediaHandler: Handler {
     }
 
     /// Get media info.
-    public func info(for mediaId: String, completionHandler: @escaping (Result<UserFeedModel, Error>) -> Void) {
-        requests.decodeAsync(UserFeedModel.self,
+    public func info(for mediaId: String, completionHandler: @escaping (Result<MediaModel, Error>) -> Void) {
+        requests.decodeAsync(MediaModel.self,
                              method: .get,
                              url: URLs.getMediaUrl(mediaId: mediaId),
                              completionHandler: completionHandler)


### PR DESCRIPTION
It was right in previous commits, but was changed to produce a wrong output.