### PR TITLE
Update to `2.1.3`

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ handler.messages.inbox(with: .init(maxPagesToLoad: .max),
                        updateHandler: nil,
                        completionHandler: { _, _ in /* do something */ })
 // …fetch all your followers.
-handler.users.following(user: .primaryKey(handler.user?.identity.primaryKey ?? -1),
+handler.users.following(user: .me,
                         with: .init(maxPagesToLoad: .max),
                         updateHandler: nil,
                         completionHandler: { _, _ in /* do something */ })

--- a/SwiftyInsta.podspec
+++ b/SwiftyInsta.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SwiftyInsta"
-  s.version      = "2.1.2"
+  s.version      = "2.1.3"
   s.summary      = "Private and Tokenless Instagram RESTful API."
 
   s.homepage     = "https://github.com/TheM4hd1/SwiftyInsta"

--- a/SwiftyInsta.xcodeproj/project.pbxproj
+++ b/SwiftyInsta.xcodeproj/project.pbxproj
@@ -1149,7 +1149,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.2;
+				MARKETING_VERSION = 2.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TheM4hd1.SwiftyInsta;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1178,7 +1178,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.2;
+				MARKETING_VERSION = 2.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TheM4hd1.SwiftyInsta;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1205,7 +1205,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 2.1.2;
+				MARKETING_VERSION = 2.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.TheM4hd1.SwiftyInsta-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
@@ -1232,7 +1232,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 2.1.2;
+				MARKETING_VERSION = 2.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.TheM4hd1.SwiftyInsta-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
@@ -1257,7 +1257,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.2;
+				MARKETING_VERSION = 2.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.TheM4hd1.SwiftyInsta-tvOS";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = appletvos;
@@ -1284,7 +1284,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.2;
+				MARKETING_VERSION = 2.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.TheM4hd1.SwiftyInsta-tvOS";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = appletvos;
@@ -1312,7 +1312,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.2;
+				MARKETING_VERSION = 2.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.TheM4hd1.SwiftyInsta-watchOS";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = watchos;
@@ -1340,7 +1340,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.2;
+				MARKETING_VERSION = 2.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.TheM4hd1.SwiftyInsta-watchOS";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = watchos;

--- a/SwiftyInsta/Local/Authentication/Authentication.swift
+++ b/SwiftyInsta/Local/Authentication/Authentication.swift
@@ -70,7 +70,7 @@ public struct Authentication {
         /// Init a `Response` with the data stored in the user's keychain
         /// and persisted through `Authentication.Response.persist()`.
         /// - Parameters:
-        ///     - key:  The `String` returned by `Authentication.Response.persist()`
+        ///     - key: The `String` returned by `Authentication.Response.persist()`
         /// - Returns: The `Response` if valid `Data` is found in the keychain, `nil` otherwise.
         public static func persisted(with key: String) -> Response? {
             let keychain = KeychainSwift()
@@ -78,6 +78,23 @@ public struct Authentication {
             guard let data = keychain.getData(key) else { return nil }
             // decode and return.
             return try? decoder.decode(Response.self, from: data)
+        }
+
+        @discardableResult
+        /// Remove a persisted `Response` from the user's keychain.
+        /// - Parameters:
+        ///     - key: The `String` returned by `Authentication.Response.persist()`
+        /// - Returns: `true` if it was found and deleted, `false` otherwise.
+        public static func invalidate(persistedWithKey key: String) -> Bool {
+            return KeychainSwift().delete(key)
+        }
+
+        @discardableResult
+        /// Remove the persisted `Response` from the user's keychain.
+        /// - Returns: `true` if it was found and deleted, `false` otherwise.
+        public func invalidate() -> Bool {
+            guard let dsUserId = storage?.dsUserId, !dsUserId.isEmpty else { return false }
+            return KeychainSwift().delete(dsUserId)
         }
     }
 

--- a/SwiftyInsta/Local/Responses/DynamicResponse.swift
+++ b/SwiftyInsta/Local/Responses/DynamicResponse.swift
@@ -86,6 +86,17 @@ public enum DynamicResponse: Equatable {
     }
 
     // MARK: Accessories
+    /// Returned a beautified description.
+    public var beautifiedDescription: String {
+        let data: Data
+        if #available(iOS 11, macOS 10.13, tvOS 11, watchOS 4, *) {
+          data = (try? self.data(options: [.prettyPrinted, .sortedKeys])) ?? Data()
+        } else {
+          data = (try? self.data(options: [.prettyPrinted])) ?? Data()
+        }
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
     /// `Any`.
     public var any: Any {
         switch self {

--- a/SwiftyInsta/Local/Responses/UserResponse.swift
+++ b/SwiftyInsta/Local/Responses/UserResponse.swift
@@ -63,6 +63,12 @@ public struct User: IdentifiableParsedResponse {
     /// The `isBusiness` value.
     public var isBusiness: Bool? { return rawResponse.isBusiness.bool }
 
+    /// A `User.Reference`.
+    public var reference: Reference {
+        return identity.primaryKey.flatMap(Reference.primaryKey)
+            ?? .username(username)
+    }
+
     // MARK: Codable
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()


### PR DESCRIPTION
Mostly QoL changes.

### What's new
- added ability to remove an `Authentication.Response` from the keychain directly, without needing to create and invalidate an `APIHandler`
- added an accessory to `User` to return a valid `User.Reference` (`reference`)
- added a `prettyPrinted` `description` (`beautifiedDescription`) to `DynamicResponse`, useful when `print`ing the `rawValue`