### PR TITLE
Handle timestamp in microseconds

### DIFF
--- a/SwiftyInsta/Local/Responses/ThreadResponse.swift
+++ b/SwiftyInsta/Local/Responses/ThreadResponse.swift
@@ -57,7 +57,7 @@ public struct Message: ItemIdentifiableParsedResponse, UserIdentifiableParsedRes
     public var sentAt: Date {
         return rawResponse.timestamp
             .double
-            .flatMap { $0 > 9_999_999_999 ? $0/1_000 : $0 }
+            .flatMap { $0 > 9_999_999_999_999 ? $0/1_000_000 : ($0 > 9_999_999_999 ? $0/1_000 : $0) }
             .flatMap { Date(timeIntervalSince1970: $0) } ?? .distantPast
     }
     /// The `text` value.

--- a/SwiftyInsta/Local/Responses/ThreadResponse.swift
+++ b/SwiftyInsta/Local/Responses/ThreadResponse.swift
@@ -57,7 +57,7 @@ public struct Message: ItemIdentifiableParsedResponse, UserIdentifiableParsedRes
     public var sentAt: Date {
         return rawResponse.timestamp
             .double
-            .flatMap { $0 > 9_999_999_999_999 ? $0/1_000_000 : ($0 > 9_999_999_999 ? $0/1_000 : $0) }
+            .flatMap { $0 / pow(10.0, max(floor(log10($0)) - 9, 0)) }
             .flatMap { Date(timeIntervalSince1970: $0) } ?? .distantPast
     }
     /// The `text` value.


### PR DESCRIPTION
It looks like the timestamp field can be in microseconds. An example `items` field in a thread response:
```
"items" : [
    {
      "clientContext" : "6647076839214872896",
      "itemId" : "29234153098340335355644632421515264",
      "itemType" : "text",
      "text" : "👋",
      "timestamp" : 1584786613698679,
      "userId" : 4608308767
    }
  ],
```