### PR TITLE
Bump dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,8 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/evgenyneu/keychain-swift.git", from: "16.0.0"),
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.0.0"),
+        .package(url: "https://github.com/evgenyneu/keychain-swift.git", from: "19.0.0"),
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.3.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/SwiftyInsta.podspec
+++ b/SwiftyInsta.podspec
@@ -23,6 +23,6 @@ Pod::Spec.new do |s|
   s.tvos.frameworks = 'UIKit'
   s.watchos.frameworks = 'UIKit'
 
-  s.dependency "CryptoSwift", "~> 1.0"
-  s.dependency "KeychainSwift", "~> 16.0"
+  s.dependency "CryptoSwift", "~> 1.3"
+  s.dependency "KeychainSwift", "~> 19.0"
 end


### PR DESCRIPTION
We need to bump dependencies to solve inconsistencies with SPM packages that have the same dependencies as SwiftyInsta has.