### PR TITLE
`LoginWebView` restrictions and better failure descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ self.credentials.code = /* the code */
 And the `completionHandler` in the previous `authenticate(with: completionHandler:)` will automatically catch the response.
 
 
-### `LoginWebViewController` (>= iOS 11 only)
+### `LoginWebViewController` (>= iOS 12 only)
 ```swift
 let login = LoginWebViewController { controller, result in
     controller.dismiss(animated: true, completion: nil)

--- a/SwiftyInsta/Helpers/HTTPHelper.swift
+++ b/SwiftyInsta/Helpers/HTTPHelper.swift
@@ -140,11 +140,19 @@ class HTTPHelper {
                             throw GenericError.custom("\(response?.url?.absoluteString ?? "_"). Invalid response. \(response?.statusCode ?? -1)")
                         }
                         // decode data.
-                        guard let dynamicResponse = try? DynamicResponse(data: data), let value = process(dynamicResponse) else {
+                        guard let dynamicResponse = try? DynamicResponse(data: data) else {
                             throw GenericError.custom([
                                 "\(response?.url?.absoluteString ?? "—").",
                                 "Invalid response.",
                                 "Processing handler returned `nil`.",
+                                "\(response?.statusCode ?? -1)"
+                            ].joined(separator: "\n"))
+                        }
+                        guard let value = process(dynamicResponse) else {
+                            throw GenericError.custom([
+                                "\(response?.url?.absoluteString ?? "—").",
+                                "Invalid response.",
+                                "Processing handler failed parsing "+dynamicResponse.beautifiedDescription+".",
                                 "\(response?.statusCode ?? -1)"
                             ].joined(separator: "\n"))
                         }

--- a/SwiftyInsta/Local/Authentication/Authentication.swift
+++ b/SwiftyInsta/Local/Authentication/Authentication.swift
@@ -17,7 +17,7 @@ public struct Authentication {
         /// Log in with username and password.
         case user(Credentials)
 
-        @available(iOS 11, *)
+        @available(iOS 12, *)
         /// Log in through web view.
         case webView(LoginWebView)
 

--- a/SwiftyInsta/UI/LoginWebView.swift
+++ b/SwiftyInsta/UI/LoginWebView.swift
@@ -11,7 +11,7 @@ import UIKit
 import WebKit
 
 // MARK: Views
-@available(iOS 11, *)
+@available(iOS 12, *)
 public class LoginWebView: WKWebView, WKNavigationDelegate {
     /// A custom user agent.
     public var userAgent: String?

--- a/SwiftyInsta/UI/LoginWebView.swift
+++ b/SwiftyInsta/UI/LoginWebView.swift
@@ -13,8 +13,6 @@ import WebKit
 // MARK: Views
 @available(iOS 12, *)
 public class LoginWebView: WKWebView, WKNavigationDelegate {
-    /// A custom user agent.
-    public var userAgent: String?
     /// Called when reaching the end of the login flow.
     /// You should probably hide the `InstagramLoginWebView` and notify the user with an activity indicator.
     public var didReachEndOfLoginFlow: (() -> Void)?
@@ -22,14 +20,18 @@ public class LoginWebView: WKWebView, WKNavigationDelegate {
     var completionHandler: ((Result<[HTTPCookie], Error>) -> Void)!
 
     // MARK: Init
-    public init(frame: CGRect, userAgent: String? = nil, didReachEndOfLoginFlow: (() -> Void)? = nil) {
+    @available(*, unavailable, message: "using a custom `userAgent` is no longer supported")
+    public init(frame: CGRect, userAgent: String?, didReachEndOfLoginFlow: (() -> Void)? = nil) {
+        fatalError("Unavailable method.")
+    }
+
+    public init(frame: CGRect, didReachEndOfLoginFlow: (() -> Void)? = nil) {
         // delete all cookies.
         HTTPCookieStorage.shared.removeCookies(since: Date.distantPast)
         // update the process pool.
         let configuration = WKWebViewConfiguration()
         configuration.processPool = WKProcessPool()
         // init login.
-        self.userAgent = userAgent
         self.didReachEndOfLoginFlow = didReachEndOfLoginFlow
         super.init(frame: frame, configuration: configuration)
         self.navigationDelegate = self
@@ -63,10 +65,9 @@ public class LoginWebView: WKWebView, WKNavigationDelegate {
             // in some iOS versions, use-agent needs to be different.
             // this use-agent works on iOS 11.4 and iOS 12.0+
             // but it won't work on lower versions.
-            me.customUserAgent = self?.userAgent
-                ?? ["(Linux; Android 5.0; iPhone Build/LRX21T)",
-                    "AppleWebKit/537.36 (KHTML, like Gecko)",
-                    "Chrome/70.0.3538.102 Mobile Safari/537.36"].joined(separator: " ")
+            me.customUserAgent = ["(Linux; Android 5.0; iPhone Build/LRX21T)",
+                                  "AppleWebKit/537.36 (KHTML, like Gecko)",
+                                  "Chrome/70.0.3538.102 Mobile Safari/537.36"].joined(separator: " ")
             // load request.
             me.load(URLRequest(url: url))
         }

--- a/SwiftyInsta/UI/LoginWebViewController.swift
+++ b/SwiftyInsta/UI/LoginWebViewController.swift
@@ -58,7 +58,7 @@ public class LoginWebViewController: UIViewController {
                 completionHandler: @escaping (LoginWebViewController, Result<(Authentication.Response, APIHandler), Error>) -> Void) {
         fatalError("Unavailable method.")
     }
-    
+
     public init(completionHandler: @escaping (LoginWebViewController, Result<(Authentication.Response, APIHandler), Error>) -> Void) {
         self.completionHandler = completionHandler
         super.init(nibName: nil, bundle: nil)

--- a/SwiftyInsta/UI/LoginWebViewController.swift
+++ b/SwiftyInsta/UI/LoginWebViewController.swift
@@ -15,8 +15,6 @@ import WebKit
 public class LoginWebViewController: UIViewController {
     /// The handler.
     public let handler = APIHandler()
-    /// The custom user agent.
-    public var userAgent: String?
     /// The completion handler. **Required**.
     public var completionHandler: (LoginWebViewController, Result<(Authentication.Response, APIHandler), Error>) -> Void
     /// The activity indicator.
@@ -55,9 +53,13 @@ public class LoginWebViewController: UIViewController {
     }
 
     // MARK: Init
-    public init(userAgent: String? = nil,
+    @available(*, unavailable, message: "using a custom `userAgent` is no longer supported")
+    public init(userAgent: String?,
                 completionHandler: @escaping (LoginWebViewController, Result<(Authentication.Response, APIHandler), Error>) -> Void) {
-        self.userAgent = userAgent
+        fatalError("Unavailable method.")
+    }
+    
+    public init(completionHandler: @escaping (LoginWebViewController, Result<(Authentication.Response, APIHandler), Error>) -> Void) {
         self.completionHandler = completionHandler
         super.init(nibName: nil, bundle: nil)
     }
@@ -76,7 +78,7 @@ public class LoginWebViewController: UIViewController {
         HTTPCookieStorage.shared.removeCookies(since: Date.distantPast)
         WKWebsiteDataStore.default().removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(),
                                                 modifiedSince: .distantPast) { [weak self] in
-                                                    self?.webView = LoginWebView(frame: self?.view.bounds ?? .zero, userAgent: self?.userAgent) {
+                                                    self?.webView = LoginWebView(frame: self?.view.bounds ?? .zero) {
                                                         UIView.animate(withDuration: TimeInterval(UINavigationController.hideShowBarDuration),
                                                                        animations: { self?.webView?.alpha = 0 },
                                                                        completion: { self?.webView?.isHidden = $0 })

--- a/SwiftyInsta/UI/LoginWebViewController.swift
+++ b/SwiftyInsta/UI/LoginWebViewController.swift
@@ -10,7 +10,7 @@
 import UIKit
 import WebKit
 
-@available(iOS 11, *)
+@available(iOS 12, *)
 /// A pre-built `UIViewController` displaying a `LoginWebView`.
 public class LoginWebViewController: UIViewController {
     /// The handler.


### PR DESCRIPTION
## Changelog
- As referenced in #168, `LoginWebView` doesn't work in iOS 11 because of the user agent being used only working on iOS 11.4 and above, for some reason (as clearly stated in code since version `1.*`, btw: we just never updated the `@availability` accordingly).
Bumping minimum availability to iOS 12, just in case.
- As referenced in #163, for most accounts, `LoginWebView` only works with the default user agent. Reversing the ability to use custom ones, introduced with #158.
- Better support for `Error` handling: now printing the actual content of the response too (e.g.
`Processing handler failed parsing { "errorBody" : "Please log back in.", "errorTitle" : "You've Been Logged Out",  "logoutReason" : 3,  "message" : "login_required", "status" : "fail" }.` instead of `Processing handler returned nil.`).
 