### PR TITLE
Fix `follow`, `unfollow` methods processes

### DIFF
--- a/SwiftyInsta.podspec
+++ b/SwiftyInsta.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SwiftyInsta"
-  s.version      = "2.3"
+  s.version      = "2.3.1"
   s.summary      = "Private and Tokenless Instagram RESTful API."
 
   s.homepage     = "https://github.com/TheM4hd1/SwiftyInsta"

--- a/SwiftyInsta/API/Handlers/UserHandler.swift
+++ b/SwiftyInsta/API/Handlers/UserHandler.swift
@@ -463,6 +463,7 @@ public final class UserHandler: Handler {
                              method: .post,
                              endpoint: Endpoint.Friendships.follow.user(pk),
                              body: .parameters(body),
+                             process: { Friendship(rawResponse: $0.friendshipStatus) },
                              completion: completionHandler)
         }
     }
@@ -500,6 +501,7 @@ public final class UserHandler: Handler {
                              method: .post,
                              endpoint: Endpoint.Friendships.unfollow.user(pk),
                              body: .parameters(body),
+                             process: { Friendship(rawResponse: $0.friendshipStatus) },
                              completion: completionHandler)
         }
     }


### PR DESCRIPTION
After #183 `follow` and `unfollow` requests returns `Friendship` response instead of `Status` response. But I forgot to set `process` for new response type. Currently doesn't parsing `Friendship` response, just returns with default values. 