### PR TITLE
Fix `TrayElement.coverMedia` always returns nil 

### DIFF
--- a/SwiftyInsta.podspec
+++ b/SwiftyInsta.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SwiftyInsta"
-  s.version      = "2.3.1"
+  s.version      = "2.3.2"
   s.summary      = "Private and Tokenless Instagram RESTful API."
 
   s.homepage     = "https://github.com/TheM4hd1/SwiftyInsta"

--- a/SwiftyInsta/Local/Responses/MediaResponse.swift
+++ b/SwiftyInsta/Local/Responses/MediaResponse.swift
@@ -9,6 +9,33 @@
 import CoreGraphics
 import Foundation
 
+/// A `Cover` response.
+public struct Cover: CoverIdentifiableParsedResponse {
+    /// The `content` value.
+    public var content: Media.Version? {
+        return Media.Version.init(rawResponse: rawResponse.croppedImageVersion)
+    }
+    
+    /// Init with `rawResponse`.
+    public init?(rawResponse: DynamicResponse) {
+        guard rawResponse != .none else { return nil }
+        self.rawResponse = rawResponse
+    }
+
+    /// The `rawResponse`.
+    public let rawResponse: DynamicResponse
+    
+    // MARK: Codable
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.rawResponse = try DynamicResponse(data: container.decode(Data.self))
+    }
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawResponse.data())
+    }
+}
+
 /// A `Media` response.
 public struct Media: IdentifiableParsedResponse {
     /// A media element `Version` response.

--- a/SwiftyInsta/Local/Responses/ParsedResponse.swift
+++ b/SwiftyInsta/Local/Responses/ParsedResponse.swift
@@ -105,3 +105,17 @@ public extension ItemIdentifiableParsedResponse {
                      identifier: rawResponse.itemId.string)
     }
 }
+
+/// An **cover identifiable** `ParsedResponse`.
+public protocol CoverIdentifiableParsedResponse: ParsedResponse {
+    /// The media identifier.
+    var mediaIdentifier: Identifier<Media> { get }
+}
+/// The default implementation.
+public extension CoverIdentifiableParsedResponse {
+    /// The media identifier.
+    var mediaIdentifier: Identifier<Media> {
+        return .init(primaryKey: nil,
+                     identifier: rawResponse.mediaId.string)
+    }
+}

--- a/SwiftyInsta/Local/Responses/StoryResponse.swift
+++ b/SwiftyInsta/Local/Responses/StoryResponse.swift
@@ -110,8 +110,8 @@ public struct TrayElement: IdentifiableParsedResponse {
     }
 
     /// The `coverMedia` value.
-    public var cover: Media? {
-        return Media(rawResponse: rawResponse.coverMedia)
+    public var cover: Cover? {
+        return Cover(rawResponse: rawResponse.coverMedia)
     }
     /// The `media` value.
     public var media: [Media] {


### PR DESCRIPTION
`TrayElement.coverMedia` is trying to parse `Media` object but returned response actually not a `Media` object. 

Is part of `highlights`.

returned response is;

``` 
"cover_media" : {
        "crop_rect" : [
          0,
          0.21875,
          1,
          0.78125
        ],
        "media_id" : "2238706.....",
        "cropped_image_version" : {
          "width" : 150,
          "url" : "https:\/\/instagram.fada1-2.fna.fbcdn.net.....",
          "height" : 150
        }
      }
```