### PR TITLE
Fix `LoginWebView` iOS 11 issues 

### DIFF
--- a/SwiftyInsta.podspec
+++ b/SwiftyInsta.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SwiftyInsta"
-  s.version      = "2.3.2"
+  s.version      = "2.3.3"
   s.summary      = "Private and Tokenless Instagram RESTful API."
 
   s.homepage     = "https://github.com/TheM4hd1/SwiftyInsta"

--- a/SwiftyInsta/API/Client/APIHandler.swift
+++ b/SwiftyInsta/API/Client/APIHandler.swift
@@ -92,7 +92,7 @@ public class APIHandler {
             }
         case .user(let credentials):
             authentication.authenticate(user: credentials, completionHandler: completionHandler)
-        #if os(iOS)
+        #if canImport(WebKit)
         case .webView(let webView):
             webView.authenticate { [weak self] in
                 guard let handler = self else { return completionHandler(.failure(GenericError.weakObjectReleased)) }

--- a/SwiftyInsta/Local/Authentication/Authentication.swift
+++ b/SwiftyInsta/Local/Authentication/Authentication.swift
@@ -11,13 +11,13 @@ import KeychainSwift
 
 /// An abstract `struct` holding login references .
 public struct Authentication {
-    #if os(iOS)
+    #if canImport(WebKit)
     /// Select the way you wish to authenticate.
     public enum Request {
         /// Log in with username and password.
         case user(Credentials)
 
-        @available(iOS 11, *)
+        @available(iOS 11, OSX 10.11, macCatalyst 13, *)
         /// Log in through web view.
         case webView(LoginWebView)
 

--- a/SwiftyInsta/Local/Authentication/Authentication.swift
+++ b/SwiftyInsta/Local/Authentication/Authentication.swift
@@ -17,7 +17,7 @@ public struct Authentication {
         /// Log in with username and password.
         case user(Credentials)
 
-        @available(iOS 11, OSX 10.11, macCatalyst 13, *)
+        @available(iOS 11, OSX 10.13, macCatalyst 13, *)
         /// Log in through web view.
         case webView(LoginWebView)
 

--- a/SwiftyInsta/Local/Authentication/Authentication.swift
+++ b/SwiftyInsta/Local/Authentication/Authentication.swift
@@ -17,7 +17,7 @@ public struct Authentication {
         /// Log in with username and password.
         case user(Credentials)
 
-        @available(iOS 12, *)
+        @available(iOS 11, *)
         /// Log in through web view.
         case webView(LoginWebView)
 

--- a/SwiftyInsta/UI/LoginWebView.swift
+++ b/SwiftyInsta/UI/LoginWebView.swift
@@ -11,7 +11,7 @@ import UIKit
 import WebKit
 
 // MARK: Views
-@available(iOS 12, *)
+@available(iOS 11, *)
 public class LoginWebView: WKWebView, WKNavigationDelegate {
     /// Called when reaching the end of the login flow.
     /// You should probably hide the `InstagramLoginWebView` and notify the user with an activity indicator.
@@ -65,7 +65,7 @@ public class LoginWebView: WKWebView, WKNavigationDelegate {
             // in some iOS versions, use-agent needs to be different.
             // this use-agent works on iOS 11.4 and iOS 12.0+
             // but it won't work on lower versions.
-            me.customUserAgent = ["Mozilla/5.0 (iPhone; CPU iPhone OS 13_4_1 like Mac OS X)",
+            me.customUserAgent = ["Mozilla/5.0 (iPhone; CPU iPhone OS \(UIDevice.current.systemVersion) like Mac OS X)",
                                   "AppleWebKit/605.1.15 (KHTML, like Gecko)",
                                   "Mobile/15E148"].joined(separator: " ")
 

--- a/SwiftyInsta/UI/LoginWebView.swift
+++ b/SwiftyInsta/UI/LoginWebView.swift
@@ -6,12 +6,12 @@
 //  Copyright © 2019 Mahdi. All rights reserved.
 //
 
-#if os(iOS)
+#if canImport(WebKit)
 import UIKit
 import WebKit
 
 // MARK: Views
-@available(iOS 11, *)
+@available(iOS 11, OSX 10.11, macCatalyst 13, *)
 public class LoginWebView: WKWebView, WKNavigationDelegate {
     /// Called when reaching the end of the login flow.
     /// You should probably hide the `InstagramLoginWebView` and notify the user with an activity indicator.
@@ -62,13 +62,16 @@ public class LoginWebView: WKWebView, WKNavigationDelegate {
             guard let url = URL(string: "https://www.instagram.com/accounts/login/") else {
                 return completionHandler(.failure(GenericError.custom("Invalid URL.")))
             }
-            // in some iOS versions, use-agent needs to be different.
-            // this use-agent works on iOS 11.4 and iOS 12.0+
-            // but it won't work on lower versions.
-            me.customUserAgent = ["Mozilla/5.0 (iPhone; CPU iPhone OS \(UIDevice.current.systemVersion) like Mac OS X)",
+            #if targetEnvironment(macCatalyst) || os(OSX)
+            me.customUserAgent = ["Mozilla/5.0 (iPhone; CPU iPhone OS 13_4_1 like Mac OS X)",
                                   "AppleWebKit/605.1.15 (KHTML, like Gecko)",
                                   "Mobile/15E148"].joined(separator: " ")
-
+            #else
+            let deviceVersion = UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")
+            me.customUserAgent = ["Mozilla/5.0 (iPhone; CPU iPhone OS \(deviceVersion) like Mac OS X)",
+                                  "AppleWebKit/605.1.15 (KHTML, like Gecko)",
+                                  "Mobile/15E148"].joined(separator: " ")
+            #endif
             // load request.
             me.load(URLRequest(url: url))
         }

--- a/SwiftyInsta/UI/LoginWebView.swift
+++ b/SwiftyInsta/UI/LoginWebView.swift
@@ -61,13 +61,13 @@ public class LoginWebView: WKWebView, WKNavigationDelegate {
             guard let url = URL(string: "https://www.instagram.com/accounts/login/") else {
                 return completionHandler(.failure(GenericError.custom("Invalid URL.")))
             }
-            #if targetEnvironment(macCatalyst) || os(OSX)
-            me.customUserAgent = ["Mozilla/5.0 (iPhone; CPU iPhone OS 13_4_1 like Mac OS X)",
+            #if os(iOS) && !targetEnvironment(macCatalyst)
+            let deviceVersion = UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")
+            me.customUserAgent = ["Mozilla/5.0 (iPhone; CPU iPhone OS \(deviceVersion) like Mac OS X)",
                                   "AppleWebKit/605.1.15 (KHTML, like Gecko)",
                                   "Mobile/15E148"].joined(separator: " ")
             #else
-            let deviceVersion = UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")
-            me.customUserAgent = ["Mozilla/5.0 (iPhone; CPU iPhone OS \(deviceVersion) like Mac OS X)",
+            me.customUserAgent = ["Mozilla/5.0 (iPhone; CPU iPhone OS 13_4_1 like Mac OS X)",
                                   "AppleWebKit/605.1.15 (KHTML, like Gecko)",
                                   "Mobile/15E148"].joined(separator: " ")
             #endif

--- a/SwiftyInsta/UI/LoginWebView.swift
+++ b/SwiftyInsta/UI/LoginWebView.swift
@@ -7,11 +7,10 @@
 //
 
 #if canImport(WebKit)
-import UIKit
 import WebKit
 
 // MARK: Views
-@available(iOS 11, OSX 10.11, macCatalyst 13, *)
+@available(iOS 11, OSX 10.13, macCatalyst 13, *)
 public class LoginWebView: WKWebView, WKNavigationDelegate {
     /// Called when reaching the end of the login flow.
     /// You should probably hide the `InstagramLoginWebView` and notify the user with an activity indicator.

--- a/SwiftyInsta/UI/LoginWebViewController.swift
+++ b/SwiftyInsta/UI/LoginWebViewController.swift
@@ -6,11 +6,11 @@
 //  Copyright © 2019 Mahdi. All rights reserved.
 //
 
-#if os(iOS)
+#if canImport(WebKit)
 import UIKit
 import WebKit
 
-@available(iOS 11, *)
+@available(iOS 11, OSX 10.11, macCatalyst 13, *)
 /// A pre-built `UIViewController` displaying a `LoginWebView`.
 public class LoginWebViewController: UIViewController {
     /// The handler.

--- a/SwiftyInsta/UI/LoginWebViewController.swift
+++ b/SwiftyInsta/UI/LoginWebViewController.swift
@@ -10,7 +10,7 @@
 import UIKit
 import WebKit
 
-@available(iOS 12, *)
+@available(iOS 11, *)
 /// A pre-built `UIViewController` displaying a `LoginWebView`.
 public class LoginWebViewController: UIViewController {
     /// The handler.

--- a/SwiftyInsta/UI/LoginWebViewController.swift
+++ b/SwiftyInsta/UI/LoginWebViewController.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Mahdi. All rights reserved.
 //
 
-#if canImport(WebKit)
+#if os(iOS)
 import UIKit
 import WebKit
 


### PR DESCRIPTION
Updated `User-Agent` works on iOS 11. Old `User-Agent` have an iOS 11+ hardcoded version and it didn't working on iOS 11 and `LoginWebView` gets stuck on `Instagram` logo, working now.