### PR TITLE
Fix for RateLimit.DeviceRateLimit

### DIFF
--- a/SwiftyInsta.podspec
+++ b/SwiftyInsta.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SwiftyInsta"
-  s.version      = "2.3.7"
+  s.version      = "2.3.8"
   s.summary      = "Private and Tokenless Instagram RESTful API."
 
   s.homepage     = "https://github.com/TheM4hd1/SwiftyInsta"

--- a/SwiftyInsta/Local/Devices/Device.swift
+++ b/SwiftyInsta/Local/Devices/Device.swift
@@ -74,8 +74,8 @@ public struct Device: Codable {
         self.brand = brand
         self.id = "android-\(deviceGuid.uuidString.md5().prefix(16))"
         self.model = model
-        self.phoneGuid = phoneGuid
-        self.deviceGuid = deviceGuid
+        self.phoneGuid = .init()// phoneGuid
+        self.deviceGuid = .init()// deviceGuid
         self.googleAdId = googleAdId
         self.rankToken = rankToken
         self.androidBoardName = androidBoardName


### PR DESCRIPTION
When trying to unfollow/follow people, you may face an error, here is the description of error:
```
  "category" : "instagram_unfollow",
  "feedbackAction" : "report_problem",
  "feedbackAppealLabel" : "Tell us",
  "feedbackIgnoreLabel" : "OK",
  "feedbackMessage" : "We limit how often you can do certain things on Instagram, like unfollowing people, to protect our community. Tell us if you think we made a mistake.",
  "feedbackTitle" : "Try Again Later",
  "feedbackUrl" : "repute\/report_problem\/instagram_unfollow\/?violation_type&responsible_policy=Ig.Policy.Engagement.DeviceRateLimit.DeviceRateLimit",
  "message" : "feedback_required",
  "spam" : true,
  "status" : "fail"
```
### How to fix?
Using a unique `device_id` can fix this problem, so I've overridden the default value of `device_id` and `phone_id` with a unique `UDID` 