### PR TITLE
Make KeychainSwiftAccessOptions configurable when persisting Authentication.Response

### DIFF
--- a/SwiftyInsta/Local/Authentication/Authentication.swift
+++ b/SwiftyInsta/Local/Authentication/Authentication.swift
@@ -54,8 +54,10 @@ public struct Authentication {
         /// Store the cache **if valid** in the user's keychain.
         /// You can save the returned value safely in your `UserDefaults`, or your database
         /// and then retrieve the `Response` when needed.
+        /// - Parameters:
+        ///     - access: An optional `KeychainSwiftAccessOptions` value.
         /// - Returns: The `key` used to store `Response` in your keychahin (the logged user's `pk`). `nil` otherwise.
-        public func persist() -> String? {
+        public func persist(withAccess access: KeychainSwiftAccessOptions? = nil) -> String? {
             let encoder = JSONEncoder()
 
             guard let dsUserId = storage?.dsUserId,
@@ -63,7 +65,7 @@ public struct Authentication {
                 let data = try? encoder.encode(self) else { return nil }
             // update keychain.
             let keychain = KeychainSwift()
-            keychain.set(data, forKey: dsUserId)
+            keychain.set(data, forKey: dsUserId, withAccess: access)
             return dsUserId
         }
 


### PR DESCRIPTION
An optional parameter (with default value being nil) is added to Authentication.Response's persist method. It can be used to specify a particular KeychainSwiftAccessOptions that's different than the default accessibleWhenUnlocked if desired by caller.