### PR TITLE
Make login cookies check more robust.

### DIFF
--- a/SwiftyInsta.podspec
+++ b/SwiftyInsta.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SwiftyInsta"
-  s.version      = "2.4.3"
+  s.version      = "2.5.0"
   s.summary      = "Private and Tokenless Instagram RESTful API."
 
   s.homepage     = "https://github.com/TheM4hd1/SwiftyInsta"


### PR DESCRIPTION
The aim of this PR is to make the checking for cookies more robust when logging in.

Cookies are not always set at page load so the current method could fail and an infinite spinner would be presented to the user, the callback never being called.

The solution is to check for cookies perpetually. When the cookies are eventually set, the callback is called and the end result is the same as before.